### PR TITLE
Add CSS code distance and logical analysis APIs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,9 @@ PyMatching/
 Stim/
 ldpc/
 
+# Local implementation worktrees
+.worktrees/
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ What it does well:
 - **Out-of-the-box decoding** with minimal setup.
 - **Inputs from parity-check matrices** or **Stim DetectorErrorModel**.
 - **Maximum-likelihood decoding** via weights or error probabilities.
+- **Exact CSS code analysis** from `Hx` and `Hz`, including code distance and logical operators.
 - **PyMatching-like API** for easy experimentation.
 
 When it is not a fit:
@@ -131,6 +132,36 @@ print(f"Correction: {correction}")
 ```
 
 Note: passing SciPy sparse matrices requires `scipy` to be installed (e.g., `uv pip install ilpqec[scipy]`).
+
+### CSS Code Distance and Logical Operators
+
+```python
+import numpy as np
+from ilpqec import CSSCode
+
+h = np.array([
+    [1, 0, 1, 0, 1, 0, 1],
+    [0, 1, 1, 0, 0, 1, 1],
+    [0, 0, 0, 1, 1, 1, 1],
+], dtype=np.uint8)
+
+code = CSSCode.from_parity_check_matrices(h, h)
+
+distance = code.distance(solver="highs")
+print(distance.d, distance.dx, distance.dz)
+print(distance.shortest_x)
+print(distance.shortest_z)
+
+basis = code.logical_basis(reduce=False)
+reduced = code.logical_basis(reduce=True, solver="highs")
+print(basis.x @ basis.z.T % 2)
+print(reduced.x)
+print(reduced.z)
+```
+
+`distance()` returns globally shortest nontrivial X/Z logical operators. `logical_basis(reduce=True)`
+instead fixes the canonical logical cosets from Gaussian elimination and reduces
+each generator to the exact minimum-weight representative of that coset.
 
 ### Stim DetectorErrorModel Decoding
 

--- a/README.md
+++ b/README.md
@@ -51,6 +51,9 @@ PyPI package and import name: `ilpqec`.
 # Basic installation
 uv pip install ilpqec
 
+# Direct HiGHS backend for decoding and CSS analysis
+uv pip install highspy
+
 # With Stim support
 uv pip install ilpqec[stim]
 
@@ -162,6 +165,13 @@ print(reduced.z)
 `distance()` returns globally shortest nontrivial X/Z logical operators. `logical_basis(reduce=True)`
 instead fixes the canonical logical cosets from Gaussian elimination and reduces
 each generator to the exact minimum-weight representative of that coset.
+
+Notes:
+- CSS analysis currently supports binary CSS codes only.
+- Exact `distance()` and `logical_basis(reduce=True)` require the direct HiGHS backend.
+- Positive solver gaps are rejected; these APIs raise instead of returning approximate results.
+- If `k == 0`, logical-operator APIs raise `ValueError`.
+- SciPy sparse `Hx` / `Hz` inputs require `uv pip install ilpqec[scipy]`.
 
 ### Stim DetectorErrorModel Decoding
 

--- a/docs/css_code.md
+++ b/docs/css_code.md
@@ -15,6 +15,23 @@ Use [`CSSCode`](/Users/nzy/pycode/ILPQEC/.worktrees/css-code-distance/src/ilpqec
 The current exact-analysis path supports binary CSS codes only and uses the
 direct HiGHS backend.
 
+## Requirements
+
+Install the core package plus any optional dependencies you need:
+
+```bash
+uv pip install ilpqec
+uv pip install highspy
+```
+
+Optional extras:
+
+- install `ilpqec[scipy]` if you want to pass SciPy sparse parity-check matrices
+- install `ilpqec[stim]` only if you also use Stim-based decoding APIs elsewhere
+
+The CSS analysis APIs require an exact direct HiGHS solve. They do not support
+Pyomo-backed solvers or approximate MIP gaps.
+
 ## Build a CSS code
 
 ```python
@@ -42,6 +59,19 @@ code = CSSCode.from_parity_check_matrices(Hx, Hz, validate_commutation=True)
 ```
 
 This checks `Hx @ Hz.T == 0 mod 2`.
+
+Accepted inputs:
+
+- dense NumPy arrays
+- Python nested lists that convert to binary matrices
+- SciPy sparse matrices when `scipy` is installed
+
+Rejected inputs:
+
+- non-binary entries
+- non-2D matrices
+- mismatched column counts
+- non-commuting `Hx, Hz` pairs unless `validate_commutation=False`
 
 ## Exact distance
 
@@ -94,6 +124,24 @@ That distinction matters:
 - `logical_basis(reduce=True)` gives a paired basis where each returned row is
   the strict minimum-weight representative of its fixed canonical coset.
 
+## Choosing the API
+
+Use `distance()` when you want code parameters:
+
+- exact `dx`, `dz`, and `d`
+- one shortest X logical
+- one shortest Z logical
+
+Use `logical_basis(reduce=False)` when you want a fast canonical paired basis
+from GF(2) elimination.
+
+Use `logical_basis(reduce=True)` when you want a paired basis but also want each
+canonical logical generator reduced exactly inside its own fixed coset.
+
+`logical_basis(reduce=True)` is not a substitute for `distance()`. A reduced
+basis generator can be heavier than the globally shortest logical operator,
+because it is constrained to remain in one selected canonical coset.
+
 ## Exactness and errors
 
 - Positive optimality gaps are rejected.
@@ -101,3 +149,31 @@ That distinction matters:
   approximate answer.
 - If `k == 0`, `distance()` and `logical_basis()` raise `ValueError` because
   logical operators are undefined.
+
+## Common errors
+
+`ImportError: Direct HiGHS backend requires highspy`
+
+- install `highspy`
+- pass `solver="highs"` or rely on the default exact backend
+
+`ImportError: Sparse CSS parity-check matrices require SciPy`
+
+- install `ilpqec[scipy]`
+- or convert sparse matrices to dense arrays before calling `CSSCode`
+
+`ValueError: CSS parity checks must commute`
+
+- ensure `Hx @ Hz.T == 0 mod 2`
+- only disable commutation validation if you explicitly want to inspect an
+  invalid pair
+
+`ValueError: CSS code has no logical qubits`
+
+- this means `k == 0`
+- distance and logical-operator APIs are undefined for such a code
+
+`ValueError: CSS distance APIs require exact optimization`
+
+- do not pass a positive `gap`
+- these APIs intentionally refuse approximate MIP solves

--- a/docs/css_code.md
+++ b/docs/css_code.md
@@ -1,0 +1,103 @@
+# CSS Code Analysis
+
+ILPQEC can analyze binary CSS stabilizer codes directly from parity-check
+matrices `Hx` and `Hz`.
+
+Use [`CSSCode`](/Users/nzy/pycode/ILPQEC/.worktrees/css-code-distance/src/ilpqec/css_code.py:49) when you want exact logical-operator analysis instead of syndrome decoding.
+
+## Scope
+
+- `CSSCode.from_parity_check_matrices(Hx, Hz)` builds a binary CSS code.
+- `code.distance()` returns exact `d`, `dx`, `dz`, and one minimum-weight X/Z logical.
+- `code.logical_basis(reduce=False)` returns a paired logical basis from GF(2) elimination.
+- `code.logical_basis(reduce=True)` keeps the same canonical logical cosets and reduces each one to its exact minimum-weight representative with ILP.
+
+The current exact-analysis path supports binary CSS codes only and uses the
+direct HiGHS backend.
+
+## Build a CSS code
+
+```python
+import numpy as np
+from ilpqec import CSSCode
+
+hx = np.array([
+    [1, 0, 1, 0, 1, 0, 1],
+    [0, 1, 1, 0, 0, 1, 1],
+    [0, 0, 0, 1, 1, 1, 1],
+], dtype=np.uint8)
+
+code = CSSCode.from_parity_check_matrices(hx, hx)
+
+print(code.n)       # 7
+print(code.k)       # 1
+print(code.rank_x)  # 3
+print(code.rank_z)  # 3
+```
+
+By default, construction validates CSS commutation:
+
+```python
+code = CSSCode.from_parity_check_matrices(Hx, Hz, validate_commutation=True)
+```
+
+This checks `Hx @ Hz.T == 0 mod 2`.
+
+## Exact distance
+
+```python
+distance = code.distance(solver="highs")
+
+print(distance.d)
+print(distance.dx, distance.dz)
+print(distance.shortest_x)
+print(distance.shortest_z)
+```
+
+`distance()` searches globally over all nontrivial X and Z logical cosets. It
+returns:
+
+- `d`: `min(dx, dz)`
+- `dx`: exact X distance
+- `dz`: exact Z distance
+- `shortest_x`: one minimum-weight X logical operator
+- `shortest_z`: one minimum-weight Z logical operator
+
+## Logical bases
+
+### Canonical paired basis
+
+```python
+basis = code.logical_basis(reduce=False)
+print(basis.x)
+print(basis.z)
+```
+
+This basis is constructed by GF(2) Gaussian elimination and paired so that
+`basis.x @ basis.z.T == I mod 2`.
+
+### Per-coset exact reduction
+
+```python
+reduced = code.logical_basis(reduce=True, solver="highs")
+print(reduced.x)
+print(reduced.z)
+```
+
+This does **not** search over all equivalent logical bases. Instead, it fixes
+the canonical logical cosets chosen by Gaussian elimination and solves one exact
+minimum-weight problem for each generator.
+
+That distinction matters:
+
+- `distance()` gives the globally shortest nontrivial X/Z logicals.
+- `logical_basis(reduce=True)` gives a paired basis where each returned row is
+  the strict minimum-weight representative of its fixed canonical coset.
+
+## Exactness and errors
+
+- Positive optimality gaps are rejected.
+- If HiGHS does not prove optimality, ILPQEC raises instead of returning an
+  approximate answer.
+- If `k == 0`, `distance()` and `logical_basis()` raise `ValueError` because
+  logical operators are undefined.

--- a/docs/index.md
+++ b/docs/index.md
@@ -51,6 +51,33 @@ error, _ = decoder.decode(syndrome)
 print(error)
 ```
 
+### CSS code analysis from `Hx` and `Hz`
+
+```python
+import numpy as np
+from ilpqec import CSSCode
+
+h = np.array([
+    [1, 0, 1, 0, 1, 0, 1],
+    [0, 1, 1, 0, 0, 1, 1],
+    [0, 0, 0, 1, 1, 1, 1],
+], dtype=np.uint8)
+
+code = CSSCode.from_parity_check_matrices(h, h)
+distance = code.distance(solver="highs")
+reduced = code.logical_basis(reduce=True, solver="highs")
+
+print(distance.d, distance.dx, distance.dz)
+print(distance.shortest_x)
+print(distance.shortest_z)
+print(reduced.x)
+print(reduced.z)
+```
+
+`distance()` returns the globally shortest X/Z logical operators. `logical_basis(reduce=True)`
+keeps the canonical logical cosets and reduces each one to the exact
+minimum-weight representative.
+
 ### Stim DetectorErrorModel decoding
 
 ```python
@@ -77,6 +104,7 @@ for i in range(5):
 
 ## Documentation Map
 
+- CSS parity-check analysis: `css_code.md`
 - Solver backends and configuration: `solvers.md`
 - ILP formulation and assumptions: `math.md`
 - Stim DEM support and caveats: `stim_dem.md`

--- a/docs/index.md
+++ b/docs/index.md
@@ -78,6 +78,9 @@ print(reduced.z)
 keeps the canonical logical cosets and reduces each one to the exact
 minimum-weight representative.
 
+This exact-analysis path currently supports binary CSS codes only and requires
+the direct HiGHS backend.
+
 ### Stim DetectorErrorModel decoding
 
 ```python

--- a/docs/superpowers/plans/2026-05-06-css-code-distance.md
+++ b/docs/superpowers/plans/2026-05-06-css-code-distance.md
@@ -1,0 +1,1515 @@
+# CSS Code Distance Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add binary CSS-code analysis APIs that compute exact code distance, shortest X/Z logical operators, and optionally reduced paired logical bases from `Hx` and `Hz`.
+
+**Architecture:** Keep code analysis separate from syndrome decoding by adding `CSSCode` plus focused GF(2) and ILP helper modules. Compute paired logical bases with pure GF(2) Gaussian elimination, then use exact ILP models for global distance and per-coset logical reduction.
+
+**Tech Stack:** Python 3.9+, NumPy, optional SciPy sparse inputs, direct HiGHS via `highspy`, optional Pyomo/Gurobi conventions inherited from existing solver configuration, pytest.
+
+---
+
+## File Structure
+
+- Create `src/ilpqec/gf2.py`: pure GF(2) row reduction, rank, nullspace, binary matrix inverse, quotient-basis extraction, and paired CSS logical basis construction.
+- Create `src/ilpqec/distance_ilp.py`: exact minimum-Hamming-weight binary ILP routines for fixed parity syndromes and nonzero logical pairing constraints.
+- Create `src/ilpqec/css_code.py`: `CSSCode`, `CSSDistanceResult`, `CSSLogicalBasis`, input normalization, validation, caching, and public API orchestration.
+- Modify `src/ilpqec/__init__.py`: export `CSSCode`, `CSSDistanceResult`, and `CSSLogicalBasis`.
+- Create `tests/test_gf2.py`: solver-free tests for GF(2) primitives and paired logical bases.
+- Create `tests/test_css_code.py`: validation and unreduced CSS API tests that do not require a solver.
+- Create `tests/test_css_distance.py`: solver-gated distance and reduced logical basis tests.
+- Create `docs/css_code.md`: documentation page for CSS code analysis.
+- Modify `README.md`, `docs/index.md`, and `mkdocs.yml`: add short user-facing links and examples.
+
+---
+
+### Task 1: GF(2) Linear Algebra Helpers
+
+**Files:**
+- Create: `src/ilpqec/gf2.py`
+- Create: `tests/test_gf2.py`
+
+- [ ] **Step 1: Write failing tests for row reduction, rank, nullspace, and binary inverse**
+
+Create `tests/test_gf2.py` with this initial content:
+
+```python
+"""Tests for GF(2) linear algebra helpers."""
+
+import numpy as np
+import pytest
+
+from ilpqec.gf2 import binary_inverse, nullspace, rank, row_basis, row_reduce
+
+
+def test_row_reduce_returns_reduced_echelon_form_and_pivots():
+    matrix = np.array(
+        [
+            [1, 1, 0, 1],
+            [1, 0, 1, 1],
+            [0, 1, 1, 0],
+        ],
+        dtype=np.uint8,
+    )
+
+    reduced = row_reduce(matrix)
+
+    expected = np.array(
+        [
+            [1, 0, 1, 1],
+            [0, 1, 1, 0],
+            [0, 0, 0, 0],
+        ],
+        dtype=np.uint8,
+    )
+    np.testing.assert_array_equal(reduced.matrix, expected)
+    assert reduced.pivot_columns == (0, 1)
+    assert reduced.rank == 2
+
+
+def test_rank_and_row_basis_ignore_dependent_rows():
+    matrix = np.array(
+        [
+            [1, 1, 0],
+            [0, 1, 1],
+            [1, 0, 1],
+        ],
+        dtype=np.uint8,
+    )
+
+    assert rank(matrix) == 2
+    basis = row_basis(matrix)
+    assert basis.shape == (2, 3)
+    assert rank(basis) == 2
+    assert rank(np.vstack([basis, matrix])) == 2
+
+
+def test_nullspace_vectors_are_a_basis():
+    matrix = np.array(
+        [
+            [1, 1, 0, 0],
+            [0, 1, 1, 0],
+        ],
+        dtype=np.uint8,
+    )
+
+    kernel = nullspace(matrix)
+
+    assert kernel.shape == (2, 4)
+    np.testing.assert_array_equal((matrix @ kernel.T) % 2, np.zeros((2, 2), dtype=np.uint8))
+    assert rank(kernel) == 2
+
+
+def test_binary_inverse_inverts_full_rank_matrix():
+    matrix = np.array(
+        [
+            [1, 1, 0],
+            [0, 1, 1],
+            [1, 0, 0],
+        ],
+        dtype=np.uint8,
+    )
+
+    inverse = binary_inverse(matrix)
+
+    np.testing.assert_array_equal((matrix @ inverse) % 2, np.eye(3, dtype=np.uint8))
+    np.testing.assert_array_equal((inverse @ matrix) % 2, np.eye(3, dtype=np.uint8))
+
+
+def test_binary_inverse_rejects_singular_matrix():
+    matrix = np.array(
+        [
+            [1, 0],
+            [1, 0],
+        ],
+        dtype=np.uint8,
+    )
+
+    with pytest.raises(ValueError, match="singular"):
+        binary_inverse(matrix)
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run:
+
+```bash
+uv run pytest tests/test_gf2.py -v
+```
+
+Expected: FAIL during import with `ModuleNotFoundError: No module named 'ilpqec.gf2'`.
+
+- [ ] **Step 3: Implement GF(2) primitives**
+
+Create `src/ilpqec/gf2.py`:
+
+```python
+"""Small GF(2) linear algebra helpers used by CSS code analysis."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable
+
+import numpy as np
+
+
+@dataclass(frozen=True)
+class RowReduction:
+    """Reduced row-echelon form data over GF(2)."""
+
+    matrix: np.ndarray
+    pivot_columns: tuple[int, ...]
+    rank: int
+
+
+def _as_gf2_matrix(matrix: np.ndarray) -> np.ndarray:
+    array = np.asarray(matrix, dtype=np.uint8) % 2
+    if array.ndim != 2:
+        raise ValueError("GF(2) matrix must be two-dimensional")
+    return array.copy()
+
+
+def row_reduce(matrix: np.ndarray) -> RowReduction:
+    """Return the reduced row-echelon form of a binary matrix over GF(2)."""
+    reduced = _as_gf2_matrix(matrix)
+    rows, cols = reduced.shape
+    pivot_columns = []
+    pivot_row = 0
+
+    for col in range(cols):
+        candidates = np.flatnonzero(reduced[pivot_row:, col])
+        if candidates.size == 0:
+            continue
+
+        source_row = pivot_row + int(candidates[0])
+        if source_row != pivot_row:
+            reduced[[pivot_row, source_row]] = reduced[[source_row, pivot_row]]
+
+        for row in range(rows):
+            if row != pivot_row and reduced[row, col]:
+                reduced[row] ^= reduced[pivot_row]
+
+        pivot_columns.append(col)
+        pivot_row += 1
+        if pivot_row == rows:
+            break
+
+    return RowReduction(
+        matrix=reduced,
+        pivot_columns=tuple(pivot_columns),
+        rank=len(pivot_columns),
+    )
+
+
+def rank(matrix: np.ndarray) -> int:
+    """Return the GF(2) rank of a binary matrix."""
+    return row_reduce(matrix).rank
+
+
+def row_basis(matrix: np.ndarray) -> np.ndarray:
+    """Return a reduced independent row basis for the rowspace of a binary matrix."""
+    reduced = row_reduce(matrix)
+    return reduced.matrix[: reduced.rank].copy()
+
+
+def nullspace(matrix: np.ndarray) -> np.ndarray:
+    """Return row vectors forming a basis for the right nullspace over GF(2)."""
+    reduced = row_reduce(matrix)
+    rows, cols = reduced.matrix.shape
+    pivots = set(reduced.pivot_columns)
+    free_columns = [col for col in range(cols) if col not in pivots]
+
+    kernel = np.zeros((len(free_columns), cols), dtype=np.uint8)
+    for out_row, free_col in enumerate(free_columns):
+        kernel[out_row, free_col] = 1
+        for pivot_row, pivot_col in enumerate(reduced.pivot_columns):
+            if pivot_row < rows and reduced.matrix[pivot_row, free_col]:
+                kernel[out_row, pivot_col] = 1
+
+    return kernel
+
+
+def binary_inverse(matrix: np.ndarray) -> np.ndarray:
+    """Return the inverse of a full-rank square binary matrix over GF(2)."""
+    matrix = _as_gf2_matrix(matrix)
+    rows, cols = matrix.shape
+    if rows != cols:
+        raise ValueError("Only square binary matrices can be inverted")
+
+    augmented = np.hstack([matrix, np.eye(rows, dtype=np.uint8)])
+    reduced = row_reduce(augmented)
+    left = reduced.matrix[:, :cols]
+    if reduced.rank != rows or not np.array_equal(left, np.eye(rows, dtype=np.uint8)):
+        raise ValueError("Matrix is singular over GF(2)")
+
+    return reduced.matrix[:, cols:].copy()
+
+
+def extend_independent_rows(
+    base: np.ndarray,
+    candidates: Iterable[np.ndarray],
+    count: int,
+) -> np.ndarray:
+    """Select candidate rows that extend the rowspace of base by count dimensions."""
+    current = row_basis(base)
+    selected = []
+    current_rank = rank(current)
+
+    for candidate in candidates:
+        candidate = np.asarray(candidate, dtype=np.uint8).reshape(1, -1) % 2
+        trial = np.vstack([current, candidate])
+        trial_rank = rank(trial)
+        if trial_rank > current_rank:
+            selected.append(candidate.reshape(-1))
+            current = row_basis(trial)
+            current_rank = trial_rank
+            if len(selected) == count:
+                break
+
+    if len(selected) != count:
+        raise ValueError("Could not find enough independent quotient representatives")
+    return np.asarray(selected, dtype=np.uint8)
+```
+
+- [ ] **Step 4: Run GF(2) primitive tests**
+
+Run:
+
+```bash
+uv run pytest tests/test_gf2.py -v
+```
+
+Expected: PASS for the five tests in `tests/test_gf2.py`.
+
+- [ ] **Step 5: Commit GF(2) primitives**
+
+Run:
+
+```bash
+git add src/ilpqec/gf2.py tests/test_gf2.py
+git commit -m "Add GF2 linear algebra helpers"
+```
+
+Expected: commit succeeds and `git status --short` only shows unrelated `refs/` if it is still untracked.
+
+---
+
+### Task 2: Paired CSS Logical Basis Construction
+
+**Files:**
+- Modify: `src/ilpqec/gf2.py`
+- Modify: `tests/test_gf2.py`
+
+- [ ] **Step 1: Add failing tests for paired CSS logical bases**
+
+Append to `tests/test_gf2.py`:
+
+```python
+from ilpqec.gf2 import css_logical_basis
+
+
+def steane_check_matrix():
+    return np.array(
+        [
+            [1, 0, 1, 0, 1, 0, 1],
+            [0, 1, 1, 0, 0, 1, 1],
+            [0, 0, 0, 1, 1, 1, 1],
+        ],
+        dtype=np.uint8,
+    )
+
+
+def test_css_logical_basis_for_steane_code_is_paired():
+    h = steane_check_matrix()
+
+    basis = css_logical_basis(h, h)
+
+    assert basis.x.shape == (1, 7)
+    assert basis.z.shape == (1, 7)
+    np.testing.assert_array_equal((h @ basis.x.T) % 2, np.zeros((3, 1), dtype=np.uint8))
+    np.testing.assert_array_equal((h @ basis.z.T) % 2, np.zeros((3, 1), dtype=np.uint8))
+    np.testing.assert_array_equal((basis.x @ basis.z.T) % 2, np.eye(1, dtype=np.uint8))
+
+
+def test_css_logical_basis_for_two_logical_code_is_paired():
+    hx = np.array([[1, 1, 0, 0]], dtype=np.uint8)
+    hz = np.array([[0, 0, 1, 1]], dtype=np.uint8)
+
+    basis = css_logical_basis(hx, hz)
+
+    assert basis.x.shape == (2, 4)
+    assert basis.z.shape == (2, 4)
+    np.testing.assert_array_equal((hz @ basis.x.T) % 2, np.zeros((1, 2), dtype=np.uint8))
+    np.testing.assert_array_equal((hx @ basis.z.T) % 2, np.zeros((1, 2), dtype=np.uint8))
+    np.testing.assert_array_equal((basis.x @ basis.z.T) % 2, np.eye(2, dtype=np.uint8))
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run:
+
+```bash
+uv run pytest tests/test_gf2.py::test_css_logical_basis_for_steane_code_is_paired tests/test_gf2.py::test_css_logical_basis_for_two_logical_code_is_paired -v
+```
+
+Expected: FAIL with `ImportError` or `AttributeError` because `css_logical_basis` is not implemented.
+
+- [ ] **Step 3: Implement `CSSLogicalBasisData` and `css_logical_basis`**
+
+Append these definitions to `src/ilpqec/gf2.py`:
+
+```python
+
+@dataclass(frozen=True)
+class CSSLogicalBasisData:
+    """Paired binary CSS logical bases."""
+
+    x: np.ndarray
+    z: np.ndarray
+
+
+def quotient_basis(super_space: np.ndarray, sub_space: np.ndarray, dimension: int) -> np.ndarray:
+    """Return representatives for super_space / sub_space."""
+    return extend_independent_rows(sub_space, super_space, dimension)
+
+
+def css_logical_basis(hx: np.ndarray, hz: np.ndarray) -> CSSLogicalBasisData:
+    """Compute paired X and Z logical bases for a binary CSS code."""
+    hx = _as_gf2_matrix(hx)
+    hz = _as_gf2_matrix(hz)
+    if hx.shape[1] != hz.shape[1]:
+        raise ValueError("Hx and Hz must have the same number of columns")
+
+    n = hx.shape[1]
+    k = n - rank(hx) - rank(hz)
+    if k < 0:
+        raise ValueError("Computed a negative number of logical qubits")
+    if k == 0:
+        return CSSLogicalBasisData(
+            x=np.zeros((0, n), dtype=np.uint8),
+            z=np.zeros((0, n), dtype=np.uint8),
+        )
+
+    x_candidates = nullspace(hz)
+    z_candidates = nullspace(hx)
+    lx = quotient_basis(x_candidates, row_basis(hx), k)
+    lz = quotient_basis(z_candidates, row_basis(hz), k)
+
+    pairing = (lx @ lz.T) % 2
+    inverse_pairing = binary_inverse(pairing)
+    paired_lz = (inverse_pairing.T @ lz) % 2
+
+    if not np.array_equal((lx @ paired_lz.T) % 2, np.eye(k, dtype=np.uint8)):
+        raise ValueError("Failed to construct paired CSS logical bases")
+
+    return CSSLogicalBasisData(x=lx.astype(np.uint8), z=paired_lz.astype(np.uint8))
+```
+
+- [ ] **Step 4: Run all GF(2) tests**
+
+Run:
+
+```bash
+uv run pytest tests/test_gf2.py -v
+```
+
+Expected: PASS for all GF(2) tests.
+
+- [ ] **Step 5: Commit paired logical basis helpers**
+
+Run:
+
+```bash
+git add src/ilpqec/gf2.py tests/test_gf2.py
+git commit -m "Add paired CSS logical basis helpers"
+```
+
+Expected: commit succeeds.
+
+---
+
+### Task 3: CSSCode API, Validation, and Unreduced Logical Basis
+
+**Files:**
+- Create: `src/ilpqec/css_code.py`
+- Modify: `src/ilpqec/__init__.py`
+- Create: `tests/test_css_code.py`
+
+- [ ] **Step 1: Write failing tests for CSSCode construction and validation**
+
+Create `tests/test_css_code.py`:
+
+```python
+"""Tests for CSSCode construction and solver-free APIs."""
+
+import numpy as np
+import pytest
+
+from ilpqec import CSSCode
+
+
+def steane_check_matrix():
+    return np.array(
+        [
+            [1, 0, 1, 0, 1, 0, 1],
+            [0, 1, 1, 0, 0, 1, 1],
+            [0, 0, 0, 1, 1, 1, 1],
+        ],
+        dtype=np.uint8,
+    )
+
+
+def test_css_code_properties_and_unreduced_logical_basis():
+    h = steane_check_matrix()
+
+    code = CSSCode.from_parity_check_matrices(h, h)
+    basis = code.logical_basis(reduce=False)
+
+    assert code.n == 7
+    assert code.k == 1
+    assert code.rank_x == 3
+    assert code.rank_z == 3
+    np.testing.assert_array_equal(code.hx, h)
+    np.testing.assert_array_equal(code.hz, h)
+    np.testing.assert_array_equal((basis.x @ basis.z.T) % 2, np.eye(1, dtype=np.uint8))
+
+
+def test_css_code_copies_matrices_for_read_only_properties():
+    hx = np.array([[1, 1, 0]], dtype=np.uint8)
+    hz = np.zeros((0, 3), dtype=np.uint8)
+    code = CSSCode.from_parity_check_matrices(hx, hz)
+
+    hx_copy = code.hx
+    hx_copy[0, 0] = 0
+
+    np.testing.assert_array_equal(code.hx, np.array([[1, 1, 0]], dtype=np.uint8))
+
+
+def test_css_code_rejects_non_binary_input():
+    hx = np.array([[2, 0, 1]], dtype=int)
+    hz = np.zeros((0, 3), dtype=np.uint8)
+
+    with pytest.raises(ValueError, match="binary"):
+        CSSCode.from_parity_check_matrices(hx, hz)
+
+
+def test_css_code_rejects_shape_mismatch():
+    hx = np.zeros((1, 3), dtype=np.uint8)
+    hz = np.zeros((1, 4), dtype=np.uint8)
+
+    with pytest.raises(ValueError, match="same number of columns"):
+        CSSCode.from_parity_check_matrices(hx, hz)
+
+
+def test_css_code_rejects_non_commuting_checks_by_default():
+    hx = np.array([[1, 0]], dtype=np.uint8)
+    hz = np.array([[1, 1]], dtype=np.uint8)
+
+    with pytest.raises(ValueError, match="commute"):
+        CSSCode.from_parity_check_matrices(hx, hz)
+
+
+def test_css_code_can_skip_commutation_validation():
+    hx = np.array([[1, 0]], dtype=np.uint8)
+    hz = np.array([[1, 1]], dtype=np.uint8)
+
+    code = CSSCode.from_parity_check_matrices(hx, hz, validate_commutation=False)
+
+    assert code.n == 2
+
+
+def test_logical_basis_raises_for_zero_logical_qubits():
+    hx = np.eye(2, dtype=np.uint8)
+    hz = np.zeros((0, 2), dtype=np.uint8)
+    code = CSSCode.from_parity_check_matrices(hx, hz)
+
+    with pytest.raises(ValueError, match="no logical qubits"):
+        code.logical_basis()
+```
+
+- [ ] **Step 2: Run CSSCode tests to verify they fail**
+
+Run:
+
+```bash
+uv run pytest tests/test_css_code.py -v
+```
+
+Expected: FAIL during import because `CSSCode` is not exported.
+
+- [ ] **Step 3: Implement CSSCode and result dataclasses**
+
+Create `src/ilpqec/css_code.py`:
+
+```python
+"""Binary CSS code analysis APIs."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional
+
+import numpy as np
+
+from ilpqec.gf2 import css_logical_basis, rank
+
+
+@dataclass(frozen=True)
+class CSSDistanceResult:
+    """Exact CSS code distance result."""
+
+    d: int
+    dx: int
+    dz: int
+    shortest_x: np.ndarray
+    shortest_z: np.ndarray
+
+
+@dataclass(frozen=True)
+class CSSLogicalBasis:
+    """Paired X/Z logical operators for a CSS code."""
+
+    x: np.ndarray
+    z: np.ndarray
+
+
+def _to_binary_matrix(matrix, name: str) -> np.ndarray:
+    try:
+        from scipy.sparse import spmatrix  # type: ignore
+    except Exception:
+        spmatrix = None
+
+    if spmatrix is not None and isinstance(matrix, spmatrix):
+        array = np.asarray(matrix.toarray())
+    else:
+        if spmatrix is None and hasattr(matrix, "toarray"):
+            raise ImportError(
+                "Sparse CSS parity-check matrices require SciPy. Install with: pip install scipy"
+            )
+        array = np.asarray(matrix)
+
+    if array.ndim != 2:
+        raise ValueError(f"{name} must be a two-dimensional binary matrix")
+    if not np.all((array == 0) | (array == 1)):
+        raise ValueError(f"{name} must be binary")
+    return array.astype(np.uint8, copy=True)
+
+
+class CSSCode:
+    """Binary CSS code built from X- and Z-type parity-check matrices."""
+
+    def __init__(self, hx: np.ndarray, hz: np.ndarray):
+        self._hx = hx
+        self._hz = hz
+        self._rank_x = rank(hx)
+        self._rank_z = rank(hz)
+        self._k = self.n - self._rank_x - self._rank_z
+        if self._k < 0:
+            raise ValueError("Computed a negative number of logical qubits")
+        self._logical_basis: Optional[CSSLogicalBasis] = None
+
+    @classmethod
+    def from_parity_check_matrices(
+        cls,
+        Hx,
+        Hz,
+        *,
+        validate_commutation: bool = True,
+    ) -> "CSSCode":
+        """Create a binary CSS code from X- and Z-type parity-check matrices."""
+        hx = _to_binary_matrix(Hx, "Hx")
+        hz = _to_binary_matrix(Hz, "Hz")
+        if hx.shape[1] != hz.shape[1]:
+            raise ValueError("Hx and Hz must have the same number of columns")
+        if validate_commutation and np.any((hx @ hz.T) % 2):
+            raise ValueError("CSS parity checks must commute: Hx @ Hz.T must be zero mod 2")
+        return cls(hx, hz)
+
+    @property
+    def hx(self) -> np.ndarray:
+        """X-type parity-check matrix."""
+        return self._hx.copy()
+
+    @property
+    def hz(self) -> np.ndarray:
+        """Z-type parity-check matrix."""
+        return self._hz.copy()
+
+    @property
+    def n(self) -> int:
+        """Number of physical qubits."""
+        return int(self._hx.shape[1])
+
+    @property
+    def k(self) -> int:
+        """Number of logical qubits."""
+        return int(self._k)
+
+    @property
+    def rank_x(self) -> int:
+        """Rank of the X-check matrix."""
+        return int(self._rank_x)
+
+    @property
+    def rank_z(self) -> int:
+        """Rank of the Z-check matrix."""
+        return int(self._rank_z)
+
+    def _require_logicals(self) -> None:
+        if self.k == 0:
+            raise ValueError("CSS code has no logical qubits; logical operators are undefined")
+
+    def _canonical_logical_basis(self) -> CSSLogicalBasis:
+        if self._logical_basis is None:
+            data = css_logical_basis(self._hx, self._hz)
+            self._logical_basis = CSSLogicalBasis(x=data.x.copy(), z=data.z.copy())
+        return self._logical_basis
+
+    def logical_basis(
+        self,
+        *,
+        reduce: bool = False,
+        solver: str = None,
+        **solver_options,
+    ) -> CSSLogicalBasis:
+        """Return paired logical bases, optionally reduced with exact ILP."""
+        self._require_logicals()
+        if reduce:
+            raise NotImplementedError("Reduced logical basis is implemented in the ILP task")
+        basis = self._canonical_logical_basis()
+        return CSSLogicalBasis(x=basis.x.copy(), z=basis.z.copy())
+
+    def distance(
+        self,
+        *,
+        solver: str = None,
+        **solver_options,
+    ) -> CSSDistanceResult:
+        """Return exact CSS code distance and shortest X/Z logicals."""
+        self._require_logicals()
+        raise NotImplementedError("Distance is implemented in the ILP task")
+```
+
+- [ ] **Step 4: Export CSSCode symbols**
+
+Modify `src/ilpqec/__init__.py` so the imports and `__all__` include the new API:
+
+```python
+from ilpqec.css_code import CSSCode, CSSDistanceResult, CSSLogicalBasis
+from ilpqec.decoder import Decoder
+from ilpqec.solver import get_available_solvers, get_default_solver, SolverConfig
+
+__version__ = "0.1.0"
+__all__ = [
+    "CSSCode",
+    "CSSDistanceResult",
+    "CSSLogicalBasis",
+    "Decoder",
+    "get_available_solvers",
+    "get_default_solver",
+    "SolverConfig",
+]
+```
+
+- [ ] **Step 5: Run solver-free CSSCode tests**
+
+Run:
+
+```bash
+uv run pytest tests/test_css_code.py -v
+```
+
+Expected: PASS for construction, validation, and unreduced logical basis tests.
+
+- [ ] **Step 6: Commit CSSCode API skeleton**
+
+Run:
+
+```bash
+git add src/ilpqec/css_code.py src/ilpqec/__init__.py tests/test_css_code.py
+git commit -m "Add CSSCode API and validation"
+```
+
+Expected: commit succeeds.
+
+---
+
+### Task 4: Exact ILP Helper for Fixed and Nonzero Logical Constraints
+
+**Files:**
+- Create: `src/ilpqec/distance_ilp.py`
+- Create: `tests/test_css_distance.py`
+
+- [ ] **Step 1: Write failing ILP helper tests**
+
+Create `tests/test_css_distance.py`:
+
+```python
+"""Tests for exact CSS distance and logical reduction ILPs."""
+
+from itertools import product
+
+import numpy as np
+import pytest
+
+from ilpqec.distance_ilp import (
+    minimize_nonzero_logical_operator,
+    minimize_weight_with_fixed_syndrome,
+)
+from ilpqec.solver import get_available_solvers
+
+
+pytestmark = pytest.mark.skipif(
+    "highs" not in get_available_solvers(),
+    reason="CSS distance ILP tests require the HiGHS backend",
+)
+
+
+def brute_force_fixed(checks, duals, rhs):
+    checks = np.asarray(checks, dtype=np.uint8)
+    duals = np.asarray(duals, dtype=np.uint8)
+    rhs = np.asarray(rhs, dtype=np.uint8)
+    n = checks.shape[1] if checks.size else duals.shape[1]
+    for weight in range(n + 1):
+        for bits in product([0, 1], repeat=n):
+            vector = np.array(bits, dtype=np.uint8)
+            if int(vector.sum()) != weight:
+                continue
+            if checks.size and np.any((checks @ vector) % 2):
+                continue
+            if np.array_equal((duals @ vector) % 2, rhs):
+                return vector
+    raise AssertionError("No feasible vector found")
+
+
+def test_minimize_weight_with_fixed_syndrome_matches_bruteforce():
+    checks = np.array([[1, 1, 0, 0]], dtype=np.uint8)
+    duals = np.array(
+        [
+            [0, 0, 1, 0],
+            [1, 0, 0, 0],
+        ],
+        dtype=np.uint8,
+    )
+    rhs = np.array([1, 0], dtype=np.uint8)
+    matrix = np.vstack([checks, duals])
+    syndrome = np.concatenate([np.zeros(checks.shape[0], dtype=np.uint8), rhs])
+
+    result = minimize_weight_with_fixed_syndrome(matrix, syndrome, solver="highs")
+
+    expected = brute_force_fixed(checks, duals, rhs)
+    np.testing.assert_array_equal((matrix @ result.vector) % 2, syndrome)
+    assert result.weight == int(expected.sum())
+
+
+def test_minimize_nonzero_logical_operator_finds_weight_one_operator():
+    checks = np.array([[1, 1, 0, 0]], dtype=np.uint8)
+    duals = np.array(
+        [
+            [0, 0, 1, 0],
+            [1, 0, 0, 0],
+        ],
+        dtype=np.uint8,
+    )
+
+    result = minimize_nonzero_logical_operator(checks, duals, solver="highs")
+
+    assert result.weight == 1
+    assert not np.any((checks @ result.vector) % 2)
+    assert np.any((duals @ result.vector) % 2)
+
+
+def test_exact_ilp_rejects_positive_gap():
+    matrix = np.array([[1, 1]], dtype=np.uint8)
+    syndrome = np.array([0], dtype=np.uint8)
+
+    with pytest.raises(ValueError, match="exact"):
+        minimize_weight_with_fixed_syndrome(matrix, syndrome, solver="highs", gap=0.1)
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run:
+
+```bash
+uv run pytest tests/test_css_distance.py -v
+```
+
+Expected: FAIL during import with `ModuleNotFoundError: No module named 'ilpqec.distance_ilp'`.
+
+- [ ] **Step 3: Implement direct HiGHS ILP helper**
+
+Create `src/ilpqec/distance_ilp.py`:
+
+```python
+"""Exact ILP helpers for CSS distance calculations."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Optional
+
+import numpy as np
+
+from ilpqec.solver import SolverConfig, get_default_solver
+
+
+@dataclass(frozen=True)
+class MinWeightResult:
+    """Minimum-weight binary vector returned by an exact ILP."""
+
+    vector: np.ndarray
+    weight: int
+    objective: float
+    status: str
+
+
+def _as_binary_matrix(matrix: np.ndarray, name: str) -> np.ndarray:
+    array = np.asarray(matrix, dtype=np.uint8) % 2
+    if array.ndim != 2:
+        raise ValueError(f"{name} must be two-dimensional")
+    return array
+
+
+def _as_binary_vector(vector: np.ndarray, name: str) -> np.ndarray:
+    array = np.asarray(vector, dtype=np.uint8) % 2
+    if array.ndim != 1:
+        raise ValueError(f"{name} must be one-dimensional")
+    return array
+
+
+def _exact_solver_config(solver: Optional[str], options: dict[str, Any]) -> SolverConfig:
+    solver_name = (solver or get_default_solver()).lower()
+    gap = options.pop("gap", None)
+    if gap not in (None, 0, 0.0):
+        raise ValueError(
+            "CSS distance APIs require exact optimization; positive gap is not allowed"
+        )
+
+    direct = options.pop("direct", None)
+    if direct is None:
+        direct = solver_name == "highs"
+    if solver_name != "highs" or not direct:
+        raise ValueError("CSS distance ILP currently supports the direct HiGHS backend")
+
+    return SolverConfig(
+        name=solver_name,
+        time_limit=options.pop("time_limit", None),
+        gap=0.0,
+        threads=options.pop("threads", None),
+        verbose=options.pop("verbose", False),
+        direct=True,
+        options=options,
+    )
+
+
+def minimize_weight_with_fixed_syndrome(
+    parity_check_matrix: np.ndarray,
+    syndrome: np.ndarray,
+    *,
+    solver: str = None,
+    **solver_options,
+) -> MinWeightResult:
+    """Minimize Hamming weight subject to Mx = syndrome over GF(2)."""
+    matrix = _as_binary_matrix(parity_check_matrix, "parity_check_matrix")
+    rhs = _as_binary_vector(syndrome, "syndrome")
+    if matrix.shape[0] != rhs.shape[0]:
+        raise ValueError("Syndrome length must match the number of parity-check rows")
+
+    config = _exact_solver_config(solver, dict(solver_options))
+    return _solve_direct_highs(matrix, rhs, selector_matrix=None, config=config)
+
+
+def minimize_nonzero_logical_operator(
+    check_matrix: np.ndarray,
+    dual_logicals: np.ndarray,
+    *,
+    solver: str = None,
+    **solver_options,
+) -> MinWeightResult:
+    """Minimize Hamming weight with zero syndrome and nonzero dual-logical pairing."""
+    checks = _as_binary_matrix(check_matrix, "check_matrix")
+    duals = _as_binary_matrix(dual_logicals, "dual_logicals")
+    if checks.shape[1] != duals.shape[1]:
+        raise ValueError("check_matrix and dual_logicals must have the same number of columns")
+    if duals.shape[0] == 0:
+        raise ValueError("At least one dual logical is required")
+
+    rhs = np.zeros(checks.shape[0], dtype=np.uint8)
+    config = _exact_solver_config(solver, dict(solver_options))
+    return _solve_direct_highs(checks, rhs, selector_matrix=duals, config=config)
+
+
+def _solve_direct_highs(
+    fixed_matrix: np.ndarray,
+    fixed_rhs: np.ndarray,
+    *,
+    selector_matrix: Optional[np.ndarray],
+    config: SolverConfig,
+) -> MinWeightResult:
+    try:
+        from highspy import (
+            Highs,
+            HighsLp,
+            HighsModelStatus,
+            HighsSparseMatrix,
+            HighsStatus,
+            HighsVarType,
+            MatrixFormat,
+        )
+    except Exception as exc:
+        raise ImportError(
+            "Direct HiGHS backend requires highspy. Install with: pip install highspy"
+        ) from exc
+
+    fixed_matrix = np.asarray(fixed_matrix, dtype=np.uint8)
+    fixed_rhs = np.asarray(fixed_rhs, dtype=np.uint8)
+    selector_matrix = (
+        None if selector_matrix is None else np.asarray(selector_matrix, dtype=np.uint8)
+    )
+
+    n = fixed_matrix.shape[1]
+    num_fixed = fixed_matrix.shape[0]
+    num_selectors = 0 if selector_matrix is None else selector_matrix.shape[0]
+    num_aux = num_fixed + num_selectors
+    num_cols = n + num_aux + num_selectors
+    sum_selector_row = 1 if num_selectors else 0
+    num_rows = num_fixed + num_selectors + sum_selector_row
+
+    highs = Highs()
+    _set_highs_option(highs, HighsStatus, "output_flag", bool(config.verbose))
+    if config.time_limit is not None:
+        _set_highs_option(highs, HighsStatus, "time_limit", float(config.time_limit))
+    if config.threads is not None:
+        _set_highs_option(highs, HighsStatus, "threads", int(config.threads))
+    _set_highs_option(highs, HighsStatus, "mip_rel_gap", 0.0)
+    for key, value in config.options.items():
+        _set_highs_option(highs, HighsStatus, key, value)
+
+    col_cost = [0.0] * num_cols
+    col_lower = [0.0] * num_cols
+    col_upper = [0.0] * num_cols
+    integrality = [HighsVarType.kInteger] * num_cols
+
+    for col in range(n):
+        col_cost[col] = 1.0
+        col_upper[col] = 1.0
+
+    for row in range(num_aux):
+        col_upper[n + row] = float(n)
+
+    selector_offset = n + num_aux
+    for row in range(num_selectors):
+        col_upper[selector_offset + row] = 1.0
+
+    row_lower = [0.0] * num_rows
+    row_upper = [0.0] * num_rows
+
+    for row in range(num_fixed):
+        rhs = float(fixed_rhs[row])
+        row_lower[row] = rhs
+        row_upper[row] = rhs
+
+    for row in range(num_selectors):
+        idx = num_fixed + row
+        row_lower[idx] = 0.0
+        row_upper[idx] = 0.0
+
+    if num_selectors:
+        row_lower[-1] = 1.0
+        row_upper[-1] = float(num_selectors)
+
+    entries = [[] for _ in range(num_cols)]
+    for row in range(num_fixed):
+        for col in np.flatnonzero(fixed_matrix[row]):
+            entries[int(col)].append((row, 1.0))
+        entries[n + row].append((row, -2.0))
+
+    for row in range(num_selectors):
+        constraint_row = num_fixed + row
+        for col in np.flatnonzero(selector_matrix[row]):
+            entries[int(col)].append((constraint_row, 1.0))
+        entries[n + num_fixed + row].append((constraint_row, -2.0))
+        entries[selector_offset + row].append((constraint_row, -1.0))
+        entries[selector_offset + row].append((num_rows - 1, 1.0))
+
+    starts = [0]
+    indices = []
+    values = []
+    for col_entries in entries:
+        for row, value in col_entries:
+            indices.append(int(row))
+            values.append(float(value))
+        starts.append(len(indices))
+
+    matrix = HighsSparseMatrix()
+    matrix.num_row_ = num_rows
+    matrix.num_col_ = num_cols
+    matrix.start_ = starts
+    matrix.index_ = indices
+    matrix.value_ = values
+    matrix.format_ = MatrixFormat.kColwise
+
+    lp = HighsLp()
+    lp.num_col_ = num_cols
+    lp.num_row_ = num_rows
+    lp.col_cost_ = col_cost
+    lp.col_lower_ = col_lower
+    lp.col_upper_ = col_upper
+    lp.row_lower_ = row_lower
+    lp.row_upper_ = row_upper
+    lp.integrality_ = integrality
+    lp.a_matrix_ = matrix
+
+    status = highs.passModel(lp)
+    if status != HighsStatus.kOk:
+        raise RuntimeError("Failed to initialize HiGHS model")
+
+    status = highs.run()
+    if status != HighsStatus.kOk:
+        raise RuntimeError("HiGHS failed to solve CSS distance model")
+
+    model_status = highs.getModelStatus()
+    if model_status != HighsModelStatus.kOptimal:
+        raise RuntimeError(f"HiGHS did not prove optimality: {model_status}")
+
+    solution = highs.getSolution()
+    vector = (np.asarray(solution.col_value[:n], dtype=float) > 0.5).astype(np.uint8)
+    objective = float(highs.getObjectiveValue())
+    return MinWeightResult(
+        vector=vector,
+        weight=int(vector.sum()),
+        objective=objective,
+        status=str(model_status),
+    )
+
+
+def _set_highs_option(highs, highs_status, key: str, value: Any) -> None:
+    status = highs.setOptionValue(key, value)
+    if status != highs_status.kOk:
+        raise ValueError(f"HiGHS rejected option '{key}'")
+```
+
+- [ ] **Step 4: Run ILP helper tests**
+
+Run:
+
+```bash
+uv run pytest tests/test_css_distance.py -v
+```
+
+Expected: PASS when HiGHS is available; otherwise the tests are skipped.
+
+- [ ] **Step 5: Commit ILP helper**
+
+Run:
+
+```bash
+git add src/ilpqec/distance_ilp.py tests/test_css_distance.py
+git commit -m "Add exact CSS distance ILP helper"
+```
+
+Expected: commit succeeds.
+
+---
+
+### Task 5: Wire Exact Distance and Reduced Logical Basis into CSSCode
+
+**Files:**
+- Modify: `src/ilpqec/css_code.py`
+- Modify: `tests/test_css_distance.py`
+- Modify: `tests/test_css_code.py`
+
+- [ ] **Step 1: Add failing public API tests for distance and reduced basis**
+
+Append to `tests/test_css_distance.py`:
+
+```python
+from ilpqec import CSSCode
+
+
+def steane_check_matrix():
+    return np.array(
+        [
+            [1, 0, 1, 0, 1, 0, 1],
+            [0, 1, 1, 0, 0, 1, 1],
+            [0, 0, 0, 1, 1, 1, 1],
+        ],
+        dtype=np.uint8,
+    )
+
+
+def assert_valid_distance_result(code, result):
+    assert result.d == min(result.dx, result.dz)
+    assert result.dx == int(result.shortest_x.sum())
+    assert result.dz == int(result.shortest_z.sum())
+    assert not np.any((code.hz @ result.shortest_x) % 2)
+    assert not np.any((code.hx @ result.shortest_z) % 2)
+
+
+def test_css_code_distance_for_steane_code():
+    h = steane_check_matrix()
+    code = CSSCode.from_parity_check_matrices(h, h)
+
+    result = code.distance(solver="highs")
+
+    assert result.d == 3
+    assert result.dx == 3
+    assert result.dz == 3
+    assert_valid_distance_result(code, result)
+
+
+def test_css_code_distance_for_two_logical_toy_code():
+    hx = np.array([[1, 1, 0, 0]], dtype=np.uint8)
+    hz = np.array([[0, 0, 1, 1]], dtype=np.uint8)
+    code = CSSCode.from_parity_check_matrices(hx, hz)
+
+    result = code.distance(solver="highs")
+
+    assert result.d == 1
+    assert result.dx == 1
+    assert result.dz == 1
+    assert_valid_distance_result(code, result)
+
+
+def test_reduced_logical_basis_is_paired_and_fixed_coset_minimal():
+    hx = np.array([[1, 1, 0, 0]], dtype=np.uint8)
+    hz = np.array([[0, 0, 1, 1]], dtype=np.uint8)
+    code = CSSCode.from_parity_check_matrices(hx, hz)
+
+    basis = code.logical_basis(reduce=True, solver="highs")
+
+    np.testing.assert_array_equal((basis.x @ basis.z.T) % 2, np.eye(2, dtype=np.uint8))
+    for index in range(code.k):
+        rhs = np.zeros(code.k, dtype=np.uint8)
+        rhs[index] = 1
+        expected_x = brute_force_fixed(hz, basis.z, rhs)
+        expected_z = brute_force_fixed(hx, basis.x, rhs)
+        assert int(basis.x[index].sum()) == int(expected_x.sum())
+        assert int(basis.z[index].sum()) == int(expected_z.sum())
+```
+
+Append to `tests/test_css_code.py`:
+
+```python
+
+def test_distance_raises_for_zero_logical_qubits():
+    hx = np.eye(2, dtype=np.uint8)
+    hz = np.zeros((0, 2), dtype=np.uint8)
+    code = CSSCode.from_parity_check_matrices(hx, hz)
+
+    with pytest.raises(ValueError, match="no logical qubits"):
+        code.distance()
+```
+
+- [ ] **Step 2: Run public API tests to verify they fail**
+
+Run:
+
+```bash
+uv run pytest tests/test_css_code.py::test_distance_raises_for_zero_logical_qubits tests/test_css_distance.py::test_css_code_distance_for_steane_code tests/test_css_distance.py::test_reduced_logical_basis_is_paired_and_fixed_coset_minimal -v
+```
+
+Expected: FAIL with `NotImplementedError` from `CSSCode.distance()` or `CSSCode.logical_basis(reduce=True)`.
+
+- [ ] **Step 3: Implement `CSSCode.distance()` and reduced logical basis**
+
+Replace the `logical_basis` and `distance` methods in `src/ilpqec/css_code.py` with:
+
+```python
+    def logical_basis(
+        self,
+        *,
+        reduce: bool = False,
+        solver: str = None,
+        **solver_options,
+    ) -> CSSLogicalBasis:
+        """Return paired logical bases, optionally reduced with exact ILP."""
+        self._require_logicals()
+        basis = self._canonical_logical_basis()
+        if not reduce:
+            return CSSLogicalBasis(x=basis.x.copy(), z=basis.z.copy())
+
+        from ilpqec.distance_ilp import minimize_weight_with_fixed_syndrome
+
+        reduced_x = np.zeros_like(basis.x)
+        reduced_z = np.zeros_like(basis.z)
+        for index in range(self.k):
+            rhs = np.zeros(self.k, dtype=np.uint8)
+            rhs[index] = 1
+
+            x_matrix = np.vstack([self._hz, basis.z])
+            x_syndrome = np.concatenate([np.zeros(self._hz.shape[0], dtype=np.uint8), rhs])
+            reduced_x[index] = minimize_weight_with_fixed_syndrome(
+                x_matrix, x_syndrome, solver=solver, **solver_options
+            ).vector
+
+            z_matrix = np.vstack([self._hx, basis.x])
+            z_syndrome = np.concatenate([np.zeros(self._hx.shape[0], dtype=np.uint8), rhs])
+            reduced_z[index] = minimize_weight_with_fixed_syndrome(
+                z_matrix, z_syndrome, solver=solver, **solver_options
+            ).vector
+
+        return CSSLogicalBasis(x=reduced_x, z=reduced_z)
+
+    def distance(
+        self,
+        *,
+        solver: str = None,
+        **solver_options,
+    ) -> CSSDistanceResult:
+        """Return exact CSS code distance and shortest X/Z logicals."""
+        self._require_logicals()
+
+        from ilpqec.distance_ilp import minimize_nonzero_logical_operator
+
+        basis = self._canonical_logical_basis()
+        shortest_x = minimize_nonzero_logical_operator(
+            self._hz, basis.z, solver=solver, **solver_options
+        )
+        shortest_z = minimize_nonzero_logical_operator(
+            self._hx, basis.x, solver=solver, **solver_options
+        )
+        return CSSDistanceResult(
+            d=min(shortest_x.weight, shortest_z.weight),
+            dx=shortest_x.weight,
+            dz=shortest_z.weight,
+            shortest_x=shortest_x.vector.copy(),
+            shortest_z=shortest_z.vector.copy(),
+        )
+```
+
+- [ ] **Step 4: Run CSS distance tests**
+
+Run:
+
+```bash
+uv run pytest tests/test_css_code.py tests/test_css_distance.py -v
+```
+
+Expected: PASS when HiGHS is available; solver-gated tests skip if HiGHS is unavailable.
+
+- [ ] **Step 5: Commit public distance and reduced logical basis APIs**
+
+Run:
+
+```bash
+git add src/ilpqec/css_code.py tests/test_css_code.py tests/test_css_distance.py
+git commit -m "Wire CSS distance and logical reduction APIs"
+```
+
+Expected: commit succeeds.
+
+---
+
+### Task 6: Documentation and Package Navigation
+
+**Files:**
+- Create: `docs/css_code.md`
+- Modify: `README.md`
+- Modify: `docs/index.md`
+- Modify: `mkdocs.yml`
+
+- [ ] **Step 1: Write documentation page**
+
+Create `docs/css_code.md`:
+
+```markdown
+# CSS Code Distance
+
+ILPQEC can analyze binary CSS stabilizer codes from X- and Z-type parity-check
+matrices. This is separate from syndrome decoding: the API computes exact code
+distance and logical operators of the code itself.
+
+## Input Convention
+
+For a CSS code on `n` qubits:
+
+- `Hx` is the matrix of X-type stabilizer checks.
+- `Hz` is the matrix of Z-type stabilizer checks.
+- Both matrices must have `n` columns.
+- By default ILPQEC checks `Hx @ Hz.T == 0 mod 2`.
+
+## Distance
+
+```python
+import numpy as np
+from ilpqec import CSSCode
+
+H = np.array([
+    [1, 0, 1, 0, 1, 0, 1],
+    [0, 1, 1, 0, 0, 1, 1],
+    [0, 0, 0, 1, 1, 1, 1],
+], dtype=np.uint8)
+
+code = CSSCode.from_parity_check_matrices(H, H)
+result = code.distance()
+
+print(result.d)          # 3
+print(result.dx, result.dz)
+print(result.shortest_x) # one minimum-weight X logical
+print(result.shortest_z) # one minimum-weight Z logical
+```
+
+The distance calculation solves exact integer programs. If the solver does not prove
+optimality, ILPQEC raises an error instead of returning an approximate distance.
+
+## Logical Bases
+
+```python
+basis = code.logical_basis(reduce=False)
+print(basis.x @ basis.z.T % 2)
+```
+
+`reduce=False` returns a paired basis from Gaussian elimination. It is valid, but not
+necessarily low weight.
+
+```python
+reduced = code.logical_basis(reduce=True)
+```
+
+`reduce=True` uses exact ILP to reduce every fixed logical coset to a minimum-weight
+representative. This does not search over all possible logical-basis choices; it reduces
+the canonical cosets selected by Gaussian elimination.
+
+## Scaling
+
+Exact distance is NP-hard in general. This feature is intended for correctness-focused
+baselines, small-to-medium code studies, and checking other constructions. Large LDPC
+instances may require long solve times.
+```
+
+- [ ] **Step 2: Add README quickstart section**
+
+Insert this section in `README.md` after the parity-check matrix decoding quickstart and before Stim DEM decoding:
+
+````markdown
+### CSS Code Distance
+
+```python
+import numpy as np
+from ilpqec import CSSCode
+
+H = np.array([
+    [1, 0, 1, 0, 1, 0, 1],
+    [0, 1, 1, 0, 0, 1, 1],
+    [0, 0, 0, 1, 1, 1, 1],
+], dtype=np.uint8)
+
+code = CSSCode.from_parity_check_matrices(H, H)
+distance = code.distance()
+
+print(distance.d)
+print(distance.shortest_x)
+print(distance.shortest_z)
+```
+
+For paired logical generators, use `code.logical_basis(reduce=False)` for the Gaussian
+elimination basis or `code.logical_basis(reduce=True)` to minimize each fixed logical
+coset with ILP.
+````
+
+- [ ] **Step 3: Link docs index and nav**
+
+Add a bullet to `docs/index.md` under Documentation Map:
+
+```markdown
+- CSS code distance and logical operators: `css_code.md`
+```
+
+Add a nav entry to `mkdocs.yml` after Mathematical Formulation:
+
+```yaml
+  - CSS Code Distance: css_code.md
+```
+
+- [ ] **Step 4: Run documentation-adjacent checks**
+
+Run:
+
+```bash
+uv run pytest tests/test_css_code.py tests/test_css_distance.py -v
+```
+
+Expected: PASS for solver-free tests and PASS or SKIP for solver-gated tests depending on HiGHS availability.
+
+- [ ] **Step 5: Commit docs**
+
+Run:
+
+```bash
+git add docs/css_code.md README.md docs/index.md mkdocs.yml
+git commit -m "Document CSS code distance API"
+```
+
+Expected: commit succeeds.
+
+---
+
+### Task 7: Full Verification and Cleanup
+
+**Files:**
+- Modify only if verification finds a defect: files touched in earlier tasks
+
+- [ ] **Step 1: Run the full test suite**
+
+Run:
+
+```bash
+uv run pytest tests/ -v
+```
+
+Expected: PASS, with any optional solver tests skipped only when their backend is unavailable.
+
+- [ ] **Step 2: Run lint if available in the environment**
+
+Run:
+
+```bash
+uv run ruff check src/ilpqec
+```
+
+Expected: PASS. If ruff is unavailable in the environment, install dev dependencies with `uv sync --extra dev` and rerun.
+
+- [ ] **Step 3: Run type checking if available in the environment**
+
+Run:
+
+```bash
+uv run mypy src/ilpqec
+```
+
+Expected: PASS. If mypy reports missing optional imports for solver backends, follow the existing repository configuration rather than adding broad ignores.
+
+- [ ] **Step 4: Inspect git status**
+
+Run:
+
+```bash
+git status --short
+```
+
+Expected: only intentional changes are present. The pre-existing untracked `refs/` directory may remain untracked and should not be added.
+
+- [ ] **Step 5: Commit verification fixes only if needed**
+
+If Step 1, 2, or 3 required code or test fixes, run:
+
+```bash
+git add src/ilpqec tests docs README.md mkdocs.yml
+git commit -m "Fix CSS code distance verification issues"
+```
+
+Expected: commit succeeds. Skip this commit if no fixes were needed.
+
+---
+
+## Self-Review Checklist
+
+- Spec coverage: Tasks 1-2 cover GF(2) basis construction, Task 3 covers public API and validation, Tasks 4-5 cover exact ILP distance and per-coset reduction, Task 6 covers docs, and Task 7 covers verification.
+- Exactness: Task 4 rejects positive MIP gaps and requires HiGHS optimal status before returning results.
+- Scope: The plan implements binary CSS stabilizer codes only and does not add non-CSS, qudit, subsystem, randomized, or approximate-distance APIs.
+- Type consistency: The plan consistently uses `CSSCode`, `CSSDistanceResult`, `CSSLogicalBasis`, `distance()`, `logical_basis()`, `hx`, `hz`, `n`, `k`, `rank_x`, and `rank_z`.
+- Worktree hygiene: The pre-existing untracked `refs/` directory is explicitly left untracked.

--- a/docs/superpowers/specs/2026-05-06-css-code-distance-design.md
+++ b/docs/superpowers/specs/2026-05-06-css-code-distance-design.md
@@ -1,0 +1,280 @@
+# CSS Code Distance and Logical Operators Design
+
+## Summary
+
+Add code-level support for binary CSS codes whose input is a pair of parity-check
+matrices `(Hx, Hz)`. The feature computes:
+
+- The exact X distance `dx`, Z distance `dz`, and code distance `d = min(dx, dz)`.
+- One minimum-weight X logical operator and one minimum-weight Z logical operator.
+- A separate logical-basis API that returns paired X/Z logical generators, optionally
+  reducing every fixed logical coset to its strict minimum-weight representative.
+
+This is a code analysis feature, not a syndrome-decoding feature. It should live beside
+the existing `Decoder` API and reuse ILPQEC's solver configuration style.
+
+## Scope
+
+The first implementation supports only binary CSS stabilizer codes:
+
+- `Hx` and `Hz` are two-dimensional binary matrices.
+- Both matrices have the same number of columns `n`.
+- The default validation requires `Hx @ Hz.T == 0 mod 2`.
+- The number of logical qubits is `k = n - rank(Hx) - rank(Hz)`.
+
+General non-CSS stabilizer codes, qudit codes, subsystem codes, and approximate or
+randomized distance bounds are out of scope for this feature.
+
+## Public API
+
+Expose a new `CSSCode` class from `ilpqec`:
+
+```python
+from ilpqec import CSSCode
+
+code = CSSCode.from_parity_check_matrices(Hx, Hz)
+
+distance = code.distance()
+print(distance.d, distance.dx, distance.dz)
+print(distance.shortest_x, distance.shortest_z)
+
+basis = code.logical_basis(reduce=True)
+print(basis.x, basis.z)
+```
+
+The constructor accepts dense Python lists, NumPy arrays, and SciPy sparse matrices when
+SciPy is installed. Inputs are normalized to `np.uint8` matrices over GF(2).
+
+Public method signatures:
+
+```python
+CSSCode.from_parity_check_matrices(
+    Hx,
+    Hz,
+    *,
+    validate_commutation: bool = True,
+) -> CSSCode
+
+CSSCode.distance(
+    *,
+    solver: str | None = None,
+    **solver_options,
+) -> CSSDistanceResult
+
+CSSCode.logical_basis(
+    *,
+    reduce: bool = False,
+    solver: str | None = None,
+    **solver_options,
+) -> CSSLogicalBasis
+```
+
+Expose read-only code properties:
+
+```python
+code.hx
+code.hz
+code.n
+code.k
+code.rank_x
+code.rank_z
+```
+
+Use small dataclasses for structured returns:
+
+```python
+CSSDistanceResult(
+    d: int,
+    dx: int,
+    dz: int,
+    shortest_x: np.ndarray,
+    shortest_z: np.ndarray,
+)
+
+CSSLogicalBasis(
+    x: np.ndarray,  # shape (k, n)
+    z: np.ndarray,  # shape (k, n)
+)
+```
+
+If `k == 0`, `distance()` and `logical_basis()` raise `ValueError` because the code has
+no nontrivial logical operators.
+
+## Module Layout
+
+Add three focused modules:
+
+- `src/ilpqec/css_code.py`: user-facing `CSSCode`, result dataclasses, validation,
+  caching, and orchestration.
+- `src/ilpqec/gf2.py`: pure GF(2) linear algebra helpers such as row reduction, rank,
+  nullspace, rowspace extension, and paired quotient-basis construction.
+- `src/ilpqec/distance_ilp.py`: exact minimum-weight binary-vector ILP routines used by
+  distance and logical-basis reduction.
+
+Keep `Decoder` unchanged except for any shared helper extraction that is necessary to
+avoid duplicating solver backend code.
+
+## Reference Behavior
+
+The design follows the same mathematical split as the reference packages in `refs/`:
+
+- TensorQEC computes null spaces and logical operators via GF(2) Gaussian elimination,
+  then uses integer programming to minimize logical operators.
+- qLDPC separates code-level logical operators and distance from decoding, and reduces
+  logical operators by solving parity constraints augmented with dual-logical constraints.
+
+ILPQEC should use these references for behavior and test expectations, but the new code
+must fit ILPQEC's Python API and solver configuration patterns.
+
+## GF(2) Logical Basis
+
+For a CSS code:
+
+```text
+X logical space = ker(Hz) / rowspace(Hx)
+Z logical space = ker(Hx) / rowspace(Hz)
+```
+
+The Gaussian-elimination layer produces paired bases `Lx` and `Lz` satisfying:
+
+```text
+Hz @ Lx.T == 0 mod 2
+Hx @ Lz.T == 0 mod 2
+Lx @ Lz.T == I_k mod 2
+```
+
+The basis does not need to be minimum weight when `reduce=False`. It only needs to be
+stable, valid, and paired. `logical_basis(reduce=True)` is responsible for strict
+minimum-weight reduction of each fixed coset.
+
+## Distance ILP
+
+The distance calculation returns only the global shortest X and Z logicals. It does not
+compute or reduce the full logical basis unless the caller asks for it separately.
+
+For X distance, solve:
+
+```text
+minimize    sum_j x_j
+subject to  Hz x = 0 mod 2
+            Lz_i x = r_i mod 2 for each i
+            sum_i r_i >= 1
+            x_j in {0, 1}
+            r_i in {0, 1}
+```
+
+Here `Lz` is the paired Z logical basis. The selector vector `r` forces the candidate
+to have nonzero pairing with the Z logical space, which excludes X stabilizers and the
+zero vector while allowing any nontrivial X logical coset.
+
+For Z distance, swap X and Z:
+
+```text
+minimize    sum_j z_j
+subject to  Hx z = 0 mod 2
+            Lx_i z = r_i mod 2 for each i
+            sum_i r_i >= 1
+            z_j in {0, 1}
+            r_i in {0, 1}
+```
+
+The objective is unweighted Hamming weight. The result stores one optimizer-selected
+minimum operator for each direction.
+
+## Logical Basis Reduction ILP
+
+`logical_basis(reduce=True)` first obtains the canonical paired basis from GF(2)
+elimination. It then reduces each fixed logical coset exactly.
+
+For the `i`th X logical, solve:
+
+```text
+minimize    sum_j x_j
+subject to  Hz x = 0 mod 2
+            Lz_i x = 1 mod 2
+            Lz_j x = 0 mod 2 for j != i
+            x_j in {0, 1}
+```
+
+For the `i`th Z logical, solve:
+
+```text
+minimize    sum_j z_j
+subject to  Hx z = 0 mod 2
+            Lx_i z = 1 mod 2
+            Lx_j z = 0 mod 2 for j != i
+            z_j in {0, 1}
+```
+
+This makes every returned generator a strict minimum-weight representative of its
+selected canonical coset. It does not search over all possible basis choices.
+
+## Solver Integration
+
+The default solver remains direct HiGHS, matching the current `Decoder` behavior.
+Callers may pass the same solver options already used by `Decoder`, including
+`solver`, `direct`, `time_limit`, `gap`, `threads`, `verbose`, and backend-specific
+options.
+
+The first implementation keeps distance-specific model building in `distance_ilp.py`.
+It shares `SolverConfig` and solver availability helpers with `Decoder`, but does not
+refactor the existing decoder backend unless implementation reveals a small, obvious
+helper extraction.
+
+Because these APIs promise exact distances and strict minimum-weight representatives,
+positive relative MIP gaps are rejected. `gap=None` and `gap=0` are accepted. If a
+solver stops before proving optimality, for example due to `time_limit`, the API raises
+`RuntimeError` instead of returning a best-known feasible vector as an exact result.
+
+## Validation and Errors
+
+Validation rules:
+
+- Reject non-two-dimensional inputs.
+- Reject matrices with different numbers of columns.
+- Reject non-binary inputs instead of silently reducing arbitrary integers modulo 2.
+- Reject non-commuting CSS checks when `validate_commutation=True`.
+- Reject `k < 0`, which indicates inconsistent rank assumptions or invalid input.
+- Raise `ValueError` for `k == 0` in APIs that require nontrivial logical operators.
+
+`validate_commutation=False` skips only the commutation check. It does not skip shape,
+binary, or rank validation.
+
+## Tests
+
+Add focused test coverage:
+
+- GF(2) row reduction, rank, nullspace, and paired logical basis identities.
+- Distance on known small CSS codes, including a Steane-style `[[7,1,3]]` case.
+- Distance returns operators that commute with the opposite stabilizers and pair
+  nontrivially with the opposite logical space.
+- `logical_basis(reduce=False)` returns paired valid bases.
+- `logical_basis(reduce=True)` returns paired bases and each row is a strict
+  minimum-weight representative of the fixed coset on small brute-force-checkable codes.
+- Validation failures for shape mismatch, non-binary entries, non-commuting checks, and
+  `k == 0`.
+
+Tests that require a solver should follow the existing solver availability skip pattern.
+Pure GF(2) and validation tests should not require a solver backend.
+
+## Documentation
+
+Add a docs page `docs/css_code.md` covering:
+
+- Binary CSS input convention: `Hx` is X-type checks and `Hz` is Z-type checks.
+- `distance()` example and result fields.
+- `logical_basis(reduce=False)` versus `logical_basis(reduce=True)`.
+- Exactness and scaling caveats for ILP-based distance calculations.
+
+Update `README.md`, `docs/index.md`, and `mkdocs.yml` to link the new page.
+
+## Acceptance Criteria
+
+- `from ilpqec import CSSCode` works.
+- Users can compute `d`, `dx`, `dz`, `shortest_x`, and `shortest_z` from binary `Hx` and
+  `Hz`.
+- Users can separately compute paired logical bases, with optional strict per-coset
+  minimum-weight reduction.
+- The existing `Decoder` tests continue to pass.
+- New tests cover validation, GF(2) helpers, distance, and logical basis reduction.
+- Documentation explains the input convention and exactness limitations.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -26,6 +26,7 @@ extra_javascript:
 
 nav:
   - Home: index.md
+  - CSS Code Analysis: css_code.md
   - Solver Backends: solvers.md
   - Mathematical Formulation: math.md
   - Stim DEM Support: stim_dem.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,7 +85,7 @@ python_files = ["test_*.py"]
 addopts = "-v --tb=short"
 
 [tool.mypy]
-python_version = "3.9"
+python_version = "3.10"
 warn_return_any = true
 warn_unused_configs = true
 ignore_missing_imports = true
@@ -96,7 +96,22 @@ target-version = "py39"
 
 [tool.ruff.lint]
 select = ["E", "F", "W", "I", "N", "D", "UP"]
-ignore = ["D100", "D104", "D107"]
+ignore = [
+    "D100",
+    "D102",
+    "D104",
+    "D105",
+    "D107",
+    "D212",
+    "D415",
+    "N803",
+    "N806",
+    "UP006",
+    "UP007",
+    "UP035",
+    "UP037",
+    "UP045",
+]
 
 [tool.ruff.lint.pydocstyle]
 convention = "google"

--- a/src/ilpqec/__init__.py
+++ b/src/ilpqec/__init__.py
@@ -27,8 +27,17 @@ Supported Solvers:
     - glpk: GNU Linear Programming Kit (Pyomo required)
 """
 
+from ilpqec.css_code import CSSCode, CSSDistanceResult, CSSLogicalBasis
 from ilpqec.decoder import Decoder
 from ilpqec.solver import get_available_solvers, get_default_solver, SolverConfig
 
 __version__ = "0.1.0"
-__all__ = ["Decoder", "get_available_solvers", "get_default_solver", "SolverConfig"]
+__all__ = [
+    "CSSCode",
+    "CSSDistanceResult",
+    "CSSLogicalBasis",
+    "Decoder",
+    "get_available_solvers",
+    "get_default_solver",
+    "SolverConfig",
+]

--- a/src/ilpqec/__init__.py
+++ b/src/ilpqec/__init__.py
@@ -6,14 +6,14 @@ an optional direct Gurobi backend and a Pyomo backend for other solvers.
 
 Example:
     >>> from ilpqec import Decoder
-    >>> 
+    >>>
     >>> # Create decoder from parity-check matrix
     >>> decoder = Decoder.from_parity_check_matrix(H)
     >>> correction = decoder.decode(syndrome)
-    >>> 
+    >>>
     >>> # Use different solver (requires Pyomo extra)
     >>> decoder.set_solver("scip", time_limit=30, direct=False)
-    >>> 
+    >>>
     >>> # Create from Stim DEM
     >>> decoder = Decoder.from_stim_dem(dem)
     >>> correction, observables = decoder.decode(detector_outcomes)
@@ -29,7 +29,7 @@ Supported Solvers:
 
 from ilpqec.css_code import CSSCode, CSSDistanceResult, CSSLogicalBasis
 from ilpqec.decoder import Decoder
-from ilpqec.solver import get_available_solvers, get_default_solver, SolverConfig
+from ilpqec.solver import SolverConfig, get_available_solvers, get_default_solver
 
 __version__ = "0.1.0"
 __all__ = [

--- a/src/ilpqec/css_code.py
+++ b/src/ilpqec/css_code.py
@@ -56,10 +56,15 @@ class CSSCode:
     """Binary CSS code built from X- and Z-type parity-check matrices."""
 
     def __init__(self, hx: np.ndarray, hz: np.ndarray):
+        hx = _to_binary_matrix(hx, "hx")
+        hz = _to_binary_matrix(hz, "hz")
+        if hx.shape[1] != hz.shape[1]:
+            raise ValueError("hx and hz must have the same number of columns")
+
         self._hx = hx
         self._hz = hz
-        self._rank_x = rank(hx)
-        self._rank_z = rank(hz)
+        self._rank_x = rank(self._hx)
+        self._rank_z = rank(self._hz)
         self._k = self.n - self._rank_x - self._rank_z
         if self._k < 0:
             raise ValueError("Computed a negative number of logical qubits")
@@ -130,10 +135,11 @@ class CSSCode:
         **solver_options,
     ) -> CSSLogicalBasis:
         """Return paired logical bases, optionally reduced with exact ILP."""
-        del solver, solver_options
         self._require_logicals()
         if reduce:
             raise NotImplementedError("Reduced logical basis is implemented in the ILP task")
+        if solver is not None or solver_options:
+            raise TypeError("solver options are not supported until reduced logical bases are implemented")
         basis = self._canonical_logical_basis()
         return CSSLogicalBasis(x=basis.x.copy(), z=basis.z.copy())
 
@@ -144,6 +150,5 @@ class CSSCode:
         **solver_options,
     ) -> CSSDistanceResult:
         """Return exact CSS code distance and shortest X/Z logicals."""
-        del solver, solver_options
         self._require_logicals()
         raise NotImplementedError("Distance is implemented in the ILP task")

--- a/src/ilpqec/css_code.py
+++ b/src/ilpqec/css_code.py
@@ -7,6 +7,10 @@ from typing import Optional
 
 import numpy as np
 
+from ilpqec.distance_ilp import (
+    minimize_nonzero_logical_operator,
+    minimize_weight_with_fixed_syndrome,
+)
 from ilpqec.gf2 import css_logical_basis, rank
 
 
@@ -131,24 +135,70 @@ class CSSCode:
         self,
         *,
         reduce: bool = False,
-        solver: str = None,
+        solver: Optional[str] = None,
         **solver_options,
     ) -> CSSLogicalBasis:
         """Return paired logical bases, optionally reduced with exact ILP."""
         self._require_logicals()
-        if reduce:
-            raise NotImplementedError("Reduced logical basis is implemented in the ILP task")
-        if solver is not None or solver_options:
-            raise TypeError("solver options are not supported until reduced logical bases are implemented")
         basis = self._canonical_logical_basis()
-        return CSSLogicalBasis(x=basis.x.copy(), z=basis.z.copy())
+        if not reduce:
+            if solver is not None or solver_options:
+                raise TypeError(
+                    "solver options are only supported when reduce=True"
+                )
+            return CSSLogicalBasis(x=basis.x.copy(), z=basis.z.copy())
+
+        reduced_x = np.zeros_like(basis.x)
+        reduced_z = np.zeros_like(basis.z)
+        for index in range(self.k):
+            rhs = np.zeros(self.k, dtype=np.uint8)
+            rhs[index] = 1
+
+            x_matrix = np.vstack([self._hz, basis.z])
+            x_syndrome = np.concatenate([np.zeros(self._hz.shape[0], dtype=np.uint8), rhs])
+            reduced_x[index] = minimize_weight_with_fixed_syndrome(
+                x_matrix,
+                x_syndrome,
+                solver=solver,
+                **solver_options,
+            ).vector
+
+            z_matrix = np.vstack([self._hx, basis.x])
+            z_syndrome = np.concatenate([np.zeros(self._hx.shape[0], dtype=np.uint8), rhs])
+            reduced_z[index] = minimize_weight_with_fixed_syndrome(
+                z_matrix,
+                z_syndrome,
+                solver=solver,
+                **solver_options,
+            ).vector
+
+        return CSSLogicalBasis(x=reduced_x, z=reduced_z)
 
     def distance(
         self,
         *,
-        solver: str = None,
+        solver: Optional[str] = None,
         **solver_options,
     ) -> CSSDistanceResult:
         """Return exact CSS code distance and shortest X/Z logicals."""
         self._require_logicals()
-        raise NotImplementedError("Distance is implemented in the ILP task")
+        basis = self._canonical_logical_basis()
+        shortest_x = minimize_nonzero_logical_operator(
+            self._hz,
+            basis.z,
+            solver=solver,
+            **solver_options,
+        )
+        shortest_z = minimize_nonzero_logical_operator(
+            self._hx,
+            basis.x,
+            solver=solver,
+            **solver_options,
+        )
+        return CSSDistanceResult(
+            d=min(shortest_x.weight, shortest_z.weight),
+            dx=shortest_x.weight,
+            dz=shortest_z.weight,
+            shortest_x=shortest_x.vector.copy(),
+            shortest_z=shortest_z.vector.copy(),
+        )

--- a/src/ilpqec/css_code.py
+++ b/src/ilpqec/css_code.py
@@ -1,0 +1,149 @@
+"""Binary CSS code analysis APIs."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional
+
+import numpy as np
+
+from ilpqec.gf2 import css_logical_basis, rank
+
+
+@dataclass(frozen=True)
+class CSSDistanceResult:
+    """Exact CSS code distance result."""
+
+    d: int
+    dx: int
+    dz: int
+    shortest_x: np.ndarray
+    shortest_z: np.ndarray
+
+
+@dataclass(frozen=True)
+class CSSLogicalBasis:
+    """Paired X/Z logical operators for a CSS code."""
+
+    x: np.ndarray
+    z: np.ndarray
+
+
+def _to_binary_matrix(matrix, name: str) -> np.ndarray:
+    try:
+        from scipy.sparse import spmatrix  # type: ignore
+    except Exception:
+        spmatrix = None
+
+    if spmatrix is not None and isinstance(matrix, spmatrix):
+        array = np.asarray(matrix.toarray())
+    else:
+        if spmatrix is None and hasattr(matrix, "toarray"):
+            raise ImportError(
+                "Sparse CSS parity-check matrices require SciPy. "
+                "Install with: pip install scipy"
+            )
+        array = np.asarray(matrix)
+
+    if array.ndim != 2:
+        raise ValueError(f"{name} must be a two-dimensional binary matrix")
+    if not np.all((array == 0) | (array == 1)):
+        raise ValueError(f"{name} must be binary")
+    return array.astype(np.uint8, copy=True)
+
+
+class CSSCode:
+    """Binary CSS code built from X- and Z-type parity-check matrices."""
+
+    def __init__(self, hx: np.ndarray, hz: np.ndarray):
+        self._hx = hx
+        self._hz = hz
+        self._rank_x = rank(hx)
+        self._rank_z = rank(hz)
+        self._k = self.n - self._rank_x - self._rank_z
+        if self._k < 0:
+            raise ValueError("Computed a negative number of logical qubits")
+        self._logical_basis: Optional[CSSLogicalBasis] = None
+
+    @classmethod
+    def from_parity_check_matrices(
+        cls,
+        Hx,
+        Hz,
+        *,
+        validate_commutation: bool = True,
+    ) -> "CSSCode":
+        """Create a binary CSS code from X- and Z-type parity-check matrices."""
+        hx = _to_binary_matrix(Hx, "Hx")
+        hz = _to_binary_matrix(Hz, "Hz")
+        if hx.shape[1] != hz.shape[1]:
+            raise ValueError("Hx and Hz must have the same number of columns")
+        if validate_commutation and np.any((hx @ hz.T) % 2):
+            raise ValueError("CSS parity checks must commute: Hx @ Hz.T must be zero mod 2")
+        return cls(hx, hz)
+
+    @property
+    def hx(self) -> np.ndarray:
+        """X-type parity-check matrix."""
+        return self._hx.copy()
+
+    @property
+    def hz(self) -> np.ndarray:
+        """Z-type parity-check matrix."""
+        return self._hz.copy()
+
+    @property
+    def n(self) -> int:
+        """Number of physical qubits."""
+        return int(self._hx.shape[1])
+
+    @property
+    def k(self) -> int:
+        """Number of logical qubits."""
+        return int(self._k)
+
+    @property
+    def rank_x(self) -> int:
+        """Rank of the X-check matrix."""
+        return int(self._rank_x)
+
+    @property
+    def rank_z(self) -> int:
+        """Rank of the Z-check matrix."""
+        return int(self._rank_z)
+
+    def _require_logicals(self) -> None:
+        if self.k == 0:
+            raise ValueError("CSS code has no logical qubits; logical operators are undefined")
+
+    def _canonical_logical_basis(self) -> CSSLogicalBasis:
+        if self._logical_basis is None:
+            data = css_logical_basis(self._hx, self._hz)
+            self._logical_basis = CSSLogicalBasis(x=data.x.copy(), z=data.z.copy())
+        return self._logical_basis
+
+    def logical_basis(
+        self,
+        *,
+        reduce: bool = False,
+        solver: str = None,
+        **solver_options,
+    ) -> CSSLogicalBasis:
+        """Return paired logical bases, optionally reduced with exact ILP."""
+        del solver, solver_options
+        self._require_logicals()
+        if reduce:
+            raise NotImplementedError("Reduced logical basis is implemented in the ILP task")
+        basis = self._canonical_logical_basis()
+        return CSSLogicalBasis(x=basis.x.copy(), z=basis.z.copy())
+
+    def distance(
+        self,
+        *,
+        solver: str = None,
+        **solver_options,
+    ) -> CSSDistanceResult:
+        """Return exact CSS code distance and shortest X/Z logicals."""
+        del solver, solver_options
+        self._require_logicals()
+        raise NotImplementedError("Distance is implemented in the ILP task")

--- a/src/ilpqec/decoder.py
+++ b/src/ilpqec/decoder.py
@@ -18,13 +18,13 @@ Example Usage:
     # From parity-check matrix (uses HiGHS by default)
     decoder = Decoder.from_parity_check_matrix(H)
     correction = decoder.decode(syndrome)
-    
+
     # Use different solver (requires Pyomo extra)
     decoder = Decoder.from_parity_check_matrix(H, solver="scip", direct=False)
-    
+
     # Change solver at runtime
     decoder.set_solver("gurobi", time_limit=60)
-    
+
     # From Stim DEM
     decoder = Decoder.from_stim_dem(dem)
     correction, observables = decoder.decode(detector_outcomes)
@@ -32,38 +32,39 @@ Example Usage:
 
 from __future__ import annotations
 
-from typing import Union, List, Optional, Tuple, Dict, Any, TYPE_CHECKING
-from pathlib import Path
 import math
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Union, cast
 
 import numpy as np
 
 from ilpqec.solver import (
     SolverConfig,
+    get_available_solvers,
     get_default_solver,
     get_pyomo_solver_name,
-    get_available_solvers,
-    require_pyomo,
-    is_pyomo_available,
     is_gurobi_available,
+    is_pyomo_available,
+    require_pyomo,
 )
 
 if TYPE_CHECKING:
+    import stim
     from scipy.sparse import spmatrix
 
 
 class Decoder:
     """
     ILP-based quantum error correction decoder.
-    
+
     This class provides a PyMatching-like API for decoding using
     Integer Linear Programming. It uses a direct HiGHS backend by
     default, with an optional direct Gurobi backend and a Pyomo backend
     for other solvers.
-    
+
     Solver switching is trivial - just call set_solver() with a different
     solver name. No need to rebuild the model.
-    
+
     Supported Solvers:
         - highs: HiGHS solver (default, direct backend)
         - gurobi: Gurobi solver (direct backend, requires license)
@@ -71,17 +72,17 @@ class Decoder:
         - cplex: IBM CPLEX (requires license, Pyomo required)
         - cbc: COIN-OR CBC (Pyomo required)
         - glpk: GNU Linear Programming Kit (Pyomo required)
-    
+
     Attributes:
         num_detectors: Number of parity checks / detectors
         num_errors: Number of error mechanisms
         num_observables: Number of logical observables (for DEM)
     """
-    
-    def __init__(self):
+
+    def __init__(self) -> None:
         """
         Initialize an empty decoder.
-        
+
         Use the class methods `from_parity_check_matrix` or `from_stim_dem`
         to create a configured decoder.
         """
@@ -89,35 +90,35 @@ class Decoder:
         self._H: Optional[np.ndarray] = None  # Parity check matrix
         self._weights: Optional[np.ndarray] = None  # Error weights
         self._observable_matrix: Optional[np.ndarray] = None  # For DEM
-        
+
         # Solver configuration
-        self._solver_config = SolverConfig()
-        self._direct_highs_solver = None
-        self._direct_gurobi_solver = None
-        self._pyomo_model = None
-        self._pyomo_solver = None
-        self._pyomo_solver_name = None
+        self._solver_config: SolverConfig = SolverConfig()
+        self._direct_highs_solver: Any = None
+        self._direct_gurobi_solver: Any = None
+        self._pyomo_model: Any = None
+        self._pyomo_solver: Any = None
+        self._pyomo_solver_name: Optional[str] = None
 
         # Last solution info
         self._last_objective: Optional[float] = None
         self._last_status: Optional[str] = None
-    
+
     # =========================================================================
     # Construction Methods
     # =========================================================================
-    
+
     @classmethod
     def from_parity_check_matrix(
         cls,
         parity_check_matrix: Union[np.ndarray, spmatrix, List[List[int]]],
-        weights: Union[float, np.ndarray, List[float]] = None,
-        error_probabilities: Union[float, np.ndarray, List[float]] = None,
-        solver: str = None,
+        weights: Optional[Union[float, np.ndarray, List[float]]] = None,
+        error_probabilities: Optional[Union[float, np.ndarray, List[float]]] = None,
+        solver: Optional[str] = None,
         **solver_options
     ) -> 'Decoder':
         """
         Create a decoder from a binary parity-check matrix.
-        
+
         Args:
             parity_check_matrix: Binary m×n matrix H where m is the number
                 of parity checks and n is the number of error mechanisms.
@@ -129,22 +130,22 @@ class Decoder:
             solver: Solver name ("highs", "scip", "gurobi", etc.)
                 Default is "highs" with the direct HiGHS backend.
             **solver_options: Solver options (time_limit, gap, verbose, direct, etc.)
-            
+
         Returns:
             Configured Decoder instance
-            
+
         Example:
             >>> H = np.array([[1, 1, 0, 0], [0, 1, 1, 0], [0, 0, 1, 1]])
             >>> decoder = Decoder.from_parity_check_matrix(H)
             >>> correction = decoder.decode([1, 0, 1])
-            
+
             >>> # With different solver
             >>> decoder = Decoder.from_parity_check_matrix(H, solver="highs")
             >>> # Use Pyomo-backed solvers
             >>> decoder = Decoder.from_parity_check_matrix(H, solver="scip", direct=False)
         """
         decoder = cls()
-        
+
         # Convert to numpy array
         try:
             from scipy.sparse import spmatrix  # type: ignore
@@ -159,10 +160,10 @@ class Decoder:
                     "Install with: pip install scipy"
                 )
             H = np.asarray(parity_check_matrix)
-        
+
         decoder._H = H % 2  # Ensure binary
         n = H.shape[1]  # Number of errors
-        
+
         # Process weights
         if weights is None:
             if error_probabilities is not None:
@@ -175,26 +176,26 @@ class Decoder:
             weights = np.asarray(weights, dtype=float)
             if weights.shape != (n,):
                 raise ValueError(f"weights must have length {n} (got {weights.shape})")
-        
+
         decoder._weights = weights
-        
+
         # Set solver
         decoder.set_solver(solver, **solver_options)
-        
+
         return decoder
-    
+
     @classmethod
     def from_stim_dem(
         cls,
         dem: Union['stim.DetectorErrorModel', str],
-        solver: str = None,
+        solver: Optional[str] = None,
         merge_parallel_edges: bool = True,
         flatten_dem: bool = True,
         **solver_options
     ) -> 'Decoder':
         """
         Create a decoder from a Stim DetectorErrorModel.
-        
+
         Args:
             dem: A stim.DetectorErrorModel or its string representation
             solver: Solver name ("highs", "scip", etc.). Default is "highs".
@@ -202,7 +203,7 @@ class Decoder:
             flatten_dem: If True, call dem.flattened() to inline repeats and
                 apply detector shifts (may increase DEM size).
             **solver_options: Solver options (time_limit, gap, verbose, direct, etc.)
-        
+
         Note:
             This parser reads only error(p) lines (tags are ignored). It ignores
             detector/logical_observable metadata and applies shift_detectors
@@ -210,10 +211,10 @@ class Decoder:
             detector_separator. The '^' separator is treated as whitespace.
             Repeat blocks are handled by flatten_dem=True (default), but can
             cause large DEM expansions. Set flatten_dem=False to fail fast.
-            
+
         Returns:
             Configured Decoder instance
-            
+
         Example:
             >>> import stim
             >>> circuit = stim.Circuit.generated("surface_code:rotated_memory_x",
@@ -226,37 +227,37 @@ class Decoder:
             >>> correction, observables = decoder.decode(detector_outcomes)
         """
         decoder = cls()
-        
+
         # Parse DEM
         H, obs_matrix, weights = decoder._parse_dem(dem, merge_parallel_edges, flatten_dem)
-        
+
         decoder._H = H
         decoder._weights = weights
         decoder._observable_matrix = obs_matrix
-        
+
         # Set solver
         decoder.set_solver(solver, **solver_options)
-        
+
         return decoder
-    
+
     @classmethod
     def from_stim_dem_file(
         cls,
         dem_path: Union[str, Path],
-        solver: str = None,
+        solver: Optional[str] = None,
         flatten_dem: bool = True,
         **solver_options
     ) -> 'Decoder':
         """
         Create a decoder from a Stim DEM file.
-        
+
         Args:
             dem_path: Path to the .dem file
             solver: Solver name
             flatten_dem: If True, call dem.flattened() to inline repeats and
                 apply detector shifts (may increase DEM size).
             **solver_options: Solver options
-            
+
         Returns:
             Configured Decoder instance
         """
@@ -265,26 +266,26 @@ class Decoder:
         return cls.from_stim_dem(
             dem_str, solver=solver, flatten_dem=flatten_dem, **solver_options
         )
-    
+
     # =========================================================================
     # Solver Configuration
     # =========================================================================
-    
+
     def set_solver(
         self,
-        solver: str = None,
-        time_limit: float = None,
-        gap: float = None,
-        threads: int = None,
+        solver: Optional[str] = None,
+        time_limit: Optional[float] = None,
+        gap: Optional[float] = None,
+        threads: Optional[int] = None,
         verbose: bool = False,
         direct: Optional[bool] = None,
         **options
-    ):
+    ) -> None:
         """
         Set or change the solver.
-        
+
         You can switch solvers at any time without rebuilding the model.
-        
+
         Args:
             solver: Solver name. Options:
                 - "highs": HiGHS solver (default, direct backend)
@@ -301,7 +302,7 @@ class Decoder:
                 Defaults to True for HiGHS. For Gurobi, defaults to True
                 when gurobipy is installed.
             **options: Additional solver-specific options
-            
+
         Example:
             >>> decoder.set_solver("scip", time_limit=30)
             >>> decoder.set_solver("highs", threads=4)
@@ -359,7 +360,7 @@ class Decoder:
         self._direct_gurobi_solver = None
         self._pyomo_solver = None
         self._pyomo_solver_name = None
-    
+
     def get_solver_options(self) -> Dict[str, Any]:
         """Get current solver configuration as a dictionary."""
         return {
@@ -371,37 +372,42 @@ class Decoder:
             "direct": self._solver_config.direct,
             **self._solver_config.options
         }
-    
+
     # =========================================================================
     # Decoding Methods
     # =========================================================================
-    
+
     def decode(
         self,
         syndrome: Union[np.ndarray, List[int]],
-        return_weight: bool = False
-    ) -> Union[np.ndarray, Tuple[np.ndarray, float], Tuple[np.ndarray, np.ndarray], Tuple[np.ndarray, np.ndarray, float]]:
+        return_weight: bool = False,
+    ) -> Union[
+        np.ndarray,
+        Tuple[np.ndarray, float],
+        Tuple[np.ndarray, np.ndarray],
+        Tuple[np.ndarray, np.ndarray, float],
+    ]:
         """
         Decode a syndrome using ILP.
-        
+
         The behavior depends on how the decoder was constructed:
         - From parity-check matrix: Returns correction vector
         - From Stim DEM: Returns (correction, observable_predictions)
-        
+
         Args:
             syndrome: Binary syndrome vector or detector outcomes
             return_weight: If True, also return the solution weight
-            
+
         Returns:
             For parity-check matrix:
                 correction: Binary vector of errors
                 weight (if return_weight): Total weight of solution
-                
+
             For Stim DEM:
-                correction: Binary vector of errors  
+                correction: Binary vector of errors
                 observables: Binary vector of observable predictions
                 weight (if return_weight): Total weight of solution
-                
+
         Example:
             >>> correction = decoder.decode([1, 0, 1])
             >>> correction, weight = decoder.decode([1, 0, 1], return_weight=True)
@@ -410,10 +416,13 @@ class Decoder:
             RuntimeError: If the solver fails to find a feasible solution.
         """
         if self._H is None:
-            raise RuntimeError("Decoder not configured. Use from_parity_check_matrix() or from_stim_dem().")
-        
+            raise RuntimeError(
+                "Decoder not configured. Use from_parity_check_matrix() or "
+                "from_stim_dem()."
+            )
+
         syndrome = np.asarray(syndrome, dtype=np.uint8) % 2
-        
+
         # Solve ILP (direct backend or Pyomo backend)
         if self._solver_config.direct:
             if self._solver_config.name == "highs":
@@ -424,12 +433,12 @@ class Decoder:
                 raise ValueError("Direct backend currently supports HiGHS and Gurobi only.")
         else:
             correction, objective = self._solve_ilp(syndrome)
-        
+
         # For DEM, compute observable predictions
         if self._observable_matrix is not None:
             observables = (self._observable_matrix @ correction) % 2
             observables = observables.astype(np.uint8)
-            
+
             if return_weight:
                 return correction, observables, objective
             return correction, observables
@@ -437,7 +446,7 @@ class Decoder:
             if return_weight:
                 return correction, objective
             return correction
-    
+
     def decode_batch(
         self,
         syndromes: np.ndarray,
@@ -445,11 +454,11 @@ class Decoder:
     ) -> Union[np.ndarray, Tuple[np.ndarray, np.ndarray]]:
         """
         Decode multiple syndromes.
-        
+
         Args:
             syndromes: 2D array of shape (num_shots, num_detectors)
             return_weights: If True, also return weights
-            
+
         Returns:
             For parity-check: corrections array
             For DEM: observable predictions array
@@ -458,57 +467,75 @@ class Decoder:
         syndromes = np.asarray(syndromes)
         if syndromes.ndim == 1:
             syndromes = syndromes.reshape(1, -1)
-        
+        if self._H is None:
+            raise RuntimeError(
+                "Decoder not configured. Use from_parity_check_matrix() or "
+                "from_stim_dem()."
+            )
+
         num_shots = syndromes.shape[0]
-        
+
         # Determine output shape
         if self._observable_matrix is not None:
             num_outputs = self._observable_matrix.shape[0]
         else:
             num_outputs = self._H.shape[1]
-        
+
         results = np.zeros((num_shots, num_outputs), dtype=np.uint8)
         weights = np.zeros(num_shots, dtype=float) if return_weights else None
-        
+
         for i in range(num_shots):
-            result = self.decode(syndromes[i], return_weight=return_weights)
-            
             if self._observable_matrix is not None:
                 if return_weights:
-                    _, obs, w = result
+                    _, obs, w = cast(
+                        tuple[np.ndarray, np.ndarray, float],
+                        self.decode(syndromes[i], return_weight=True),
+                    )
                     results[i] = obs
+                    assert weights is not None
                     weights[i] = w
                 else:
-                    _, obs = result
+                    _, obs = cast(
+                        tuple[np.ndarray, np.ndarray],
+                        self.decode(syndromes[i], return_weight=False),
+                    )
                     results[i] = obs
             else:
                 if return_weights:
-                    corr, w = result
+                    corr, w = cast(
+                        tuple[np.ndarray, float],
+                        self.decode(syndromes[i], return_weight=True),
+                    )
                     results[i] = corr
+                    assert weights is not None
                     weights[i] = w
                 else:
-                    results[i] = result
-        
+                    results[i] = cast(
+                        np.ndarray,
+                        self.decode(syndromes[i], return_weight=False),
+                    )
+
         if return_weights:
+            assert weights is not None
             return results, weights
         return results
-    
+
     # =========================================================================
     # ILP Model Building and Solving (Pyomo)
     # =========================================================================
-    
+
     def _solve_ilp(self, syndrome: np.ndarray) -> Tuple[np.ndarray, float]:
         """
         Build and solve the ILP model using Pyomo.
-        
+
         ILP Formulation:
             Variables:
                 e[j] ∈ {0,1} for j = 0,...,n-1 (error indicators)
                 a[i] ∈ Z≥0 for i = 0,...,m-1 (auxiliary for mod-2)
-            
+
             Objective:
                 minimize Σ_j weight[j] * e[j]
-            
+
             Constraints (mod-2 linearization):
                 Σ_j H[i,j] * e[j] = syndrome[i] + 2 * a[i]  for all i
         """
@@ -516,14 +543,15 @@ class Decoder:
         from pyomo.environ import SolverFactory, TerminationCondition, value
 
         H = self._H
+        assert H is not None
         m, n = H.shape
-        
+
         if self._pyomo_model is None:
             self._pyomo_model = self._build_pyomo_model()
         model = self._pyomo_model
         for i in range(m):
             model.syndrome_rhs[i] = int(syndrome[i])
-        
+
         # Get solver
         solver_name = get_pyomo_solver_name(self._solver_config.name)
         solver = self._pyomo_solver
@@ -542,14 +570,14 @@ class Decoder:
                 solver.options[key] = val
             self._pyomo_solver = solver
             self._pyomo_solver_name = solver_name
-        
+
         # Solve
         tee = self._solver_config.verbose
         results = solver.solve(model, tee=tee)
-        
+
         # Check status
         self._last_status = str(results.solver.termination_condition)
-        
+
         if results.solver.termination_condition not in (
             TerminationCondition.optimal,
             TerminationCondition.feasible,
@@ -559,32 +587,35 @@ class Decoder:
             raise RuntimeError(
                 f"Solver terminated with status {results.solver.termination_condition}"
             )
-        
+
         # Extract solution
         correction = np.zeros(n, dtype=np.uint8)
         for j in range(n):
             val = value(model.e[j])
             correction[j] = 1 if val is not None and val > 0.5 else 0
-        
-        self._last_objective = value(model.obj)
-        
-        return correction, self._last_objective
+
+        objective = value(model.obj)
+        self._last_objective = float(objective)
+
+        return correction, float(objective)
 
     def _build_pyomo_model(self) -> Any:
         require_pyomo()
         from pyomo.environ import (
-            ConcreteModel,
-            Var,
-            Param,
-            Constraint,
-            Objective,
             Binary,
+            ConcreteModel,
+            Constraint,
             NonNegativeIntegers,
+            Objective,
+            Param,
+            Var,
             minimize,
         )
 
         H = self._H
         weights = self._weights
+        assert H is not None
+        assert weights is not None
         m, n = H.shape
         row_sums = np.sum(H, axis=1).astype(int)
 
@@ -612,6 +643,8 @@ class Decoder:
     def _solve_direct_highs(self, syndrome: np.ndarray) -> Tuple[np.ndarray, float]:
         """Solve the ILP using a direct HiGHS model reused across shots."""
         if self._direct_highs_solver is None:
+            assert self._H is not None
+            assert self._weights is not None
             self._direct_highs_solver = _DirectHighsSolver(
                 self._H, self._weights, self._solver_config
             )
@@ -625,6 +658,8 @@ class Decoder:
         if self._direct_gurobi_solver is None:
             from ilpqec.gurobi_backend import DirectGurobiSolver
 
+            assert self._H is not None
+            assert self._weights is not None
             self._direct_gurobi_solver = DirectGurobiSolver(
                 self._H, self._weights, self._solver_config
             )
@@ -632,14 +667,14 @@ class Decoder:
         self._last_status = status
         self._last_objective = objective
         return correction, objective
-    
+
     # =========================================================================
     # Helper Methods
     # =========================================================================
-    
+
     def _probabilities_to_weights(
-        self, 
-        probs: Union[float, np.ndarray, List[float]], 
+        self,
+        probs: Union[float, np.ndarray, List[float]],
         n: int
     ) -> np.ndarray:
         """Convert error probabilities to log-likelihood ratio weights (p in (0, 0.5])."""
@@ -659,12 +694,12 @@ class Decoder:
 
         # Clip to avoid numerical issues
         probs = np.clip(probs, 1e-15, 1 - 1e-15)
-        
+
         # Log-likelihood ratio: weight = log((1-p)/p)
         weights = np.log((1 - probs) / probs)
-        
-        return np.maximum(weights, 0.0)  # Keep non-negative for minimization
-    
+
+        return np.asarray(np.maximum(weights, 0.0), dtype=float)
+
     def _parse_dem(
         self,
         dem: Union['stim.DetectorErrorModel', str],
@@ -680,11 +715,11 @@ class Decoder:
             dem = stim.DetectorErrorModel(dem)
         if flatten_dem:
             dem = dem.flattened()
-        
+
         # Extract error mechanisms
-        errors = []
-        seen = {}  # For merging parallel edges
-        
+        errors: list[tuple[float, set[int], set[int]]] = []
+        seen: dict[tuple[tuple[int, ...], tuple[int, ...]], int] = {}
+
         dem_str = str(dem)
         detector_offset = 0
         for line in dem_str.strip().split('\n'):
@@ -718,7 +753,7 @@ class Decoder:
                 if line_lower.startswith('detector') or line_lower.startswith('logical_observable'):
                     continue
                 raise ValueError(f"Unsupported DEM instruction: {line}")
-            
+
             # Parse error(p) D... L...
             try:
                 prob_start = line.index('(') + 1
@@ -726,14 +761,14 @@ class Decoder:
             except ValueError as exc:
                 raise ValueError(f"Invalid error instruction: {line}") from exc
             prob = float(line[prob_start:prob_end])
-            
+
             if prob <= 0 or prob >= 1:
                 continue
-            
+
             targets_str = line[prob_end + 1:].strip()
-            detectors = set()
-            observables = set()
-            
+            detectors: set[int] = set()
+            observables: set[int] = set()
+
             for target in targets_str.replace("^", " ").split():
                 target = target.strip()
                 if target.startswith('D'):
@@ -754,10 +789,10 @@ class Decoder:
                         observables.remove(obs_id)
                     else:
                         observables.add(obs_id)
-            
+
             if not detectors and not observables:
                 continue
-            
+
             if merge_parallel:
                 key = (tuple(sorted(detectors)), tuple(sorted(observables)))
                 if key in seen:
@@ -769,12 +804,12 @@ class Decoder:
                     continue
                 else:
                     seen[key] = len(errors)
-            
+
             errors.append((prob, detectors, observables))
-        
+
         if not errors:
             raise ValueError("No valid error mechanisms found in DEM")
-        
+
         # Determine dimensions
         num_errors = len(errors)
         if hasattr(dem, "num_detectors"):
@@ -789,70 +824,70 @@ class Decoder:
             num_observables = (
                 max(max(e[2]) for e in errors if e[2]) + 1 if any(e[2] for e in errors) else 0
             )
-        
+
         # Build matrices
         H = np.zeros((num_detectors, num_errors), dtype=np.uint8)
         obs_matrix = np.zeros((num_observables, num_errors), dtype=np.uint8)
         weights = np.zeros(num_errors)
-        
+
         for j, (prob, dets, obs) in enumerate(errors):
             for d in dets:
                 H[d, j] = 1
             for o in obs:
                 obs_matrix[o, j] = 1
-            
+
             # Weight = log((1-p)/p)
             prob = max(1e-15, min(prob, 1 - 1e-15))
             weights[j] = math.log((1 - prob) / prob)
-        
+
         return H, obs_matrix, weights
-    
+
     # =========================================================================
     # Properties
     # =========================================================================
-    
+
     @property
     def num_detectors(self) -> int:
         """Number of detectors / parity checks."""
         return self._H.shape[0] if self._H is not None else 0
-    
+
     @property
     def num_errors(self) -> int:
         """Number of error mechanisms."""
         return self._H.shape[1] if self._H is not None else 0
-    
+
     @property
     def num_observables(self) -> int:
         """Number of logical observables (for DEM)."""
         return self._observable_matrix.shape[0] if self._observable_matrix is not None else 0
-    
+
     @property
     def solver_name(self) -> str:
         """Name of the configured solver."""
         return self._solver_config.name
-    
+
     @property
     def last_objective(self) -> Optional[float]:
         """Objective value from the last decode() call."""
         return self._last_objective
-    
+
     @property
     def last_status(self) -> Optional[str]:
         """Solver status from the last decode() call."""
         return self._last_status
-    
+
     def get_parity_check_matrix(self) -> Optional[np.ndarray]:
         """Get the parity-check matrix."""
         return self._H
-    
+
     def get_weights(self) -> Optional[np.ndarray]:
         """Get the weights for each error mechanism."""
         return self._weights
-    
+
     def __repr__(self) -> str:
         if self._H is None:
             return "<Decoder (not configured)>"
-        
+
         if self._observable_matrix is not None:
             return (
                 f"<Decoder: {self.num_detectors} detectors, {self.num_errors} errors, "
@@ -870,11 +905,11 @@ class _DirectHighsSolver:
             from highspy import (
                 Highs,
                 HighsLp,
+                HighsModelStatus,
                 HighsSparseMatrix,
+                HighsStatus,
                 HighsVarType,
                 MatrixFormat,
-                HighsStatus,
-                HighsModelStatus,
             )
         except Exception as exc:
             raise ImportError(
@@ -1001,4 +1036,3 @@ class _DirectHighsSolver:
         correction = (values > 0.5).astype(np.uint8)
         objective = float(self._highs.getObjectiveValue())
         return correction, objective, str(model_status)
-

--- a/src/ilpqec/distance_ilp.py
+++ b/src/ilpqec/distance_ilp.py
@@ -67,7 +67,7 @@ def minimize_weight_with_fixed_syndrome(
     parity_check_matrix: np.ndarray,
     syndrome: np.ndarray,
     *,
-    solver: str = None,
+    solver: Optional[str] = None,
     **solver_options,
 ) -> MinWeightResult:
     """Minimize Hamming weight subject to Mx = syndrome over GF(2)."""
@@ -84,7 +84,7 @@ def minimize_nonzero_logical_operator(
     check_matrix: np.ndarray,
     dual_logicals: np.ndarray,
     *,
-    solver: str = None,
+    solver: Optional[str] = None,
     **solver_options,
 ) -> MinWeightResult:
     """Minimize Hamming weight with zero syndrome and nonzero dual-logical pairing."""
@@ -179,7 +179,7 @@ def _solve_direct_highs(
         row_lower[-1] = 1.0
         row_upper[-1] = float(num_selectors)
 
-    entries = [[] for _ in range(num_cols)]
+    entries: list[list[tuple[int, float]]] = [[] for _ in range(num_cols)]
     for row in range(num_fixed):
         for col in np.flatnonzero(fixed_matrix[row]):
             entries[int(col)].append((row, 1.0))
@@ -187,6 +187,7 @@ def _solve_direct_highs(
 
     for row in range(num_selectors):
         constraint_row = num_fixed + row
+        assert selector_matrix is not None
         for col in np.flatnonzero(selector_matrix[row]):
             entries[int(col)].append((constraint_row, 1.0))
         entries[n + num_fixed + row].append((constraint_row, -2.0))

--- a/src/ilpqec/distance_ilp.py
+++ b/src/ilpqec/distance_ilp.py
@@ -21,17 +21,21 @@ class MinWeightResult:
 
 
 def _as_binary_matrix(matrix: np.ndarray, name: str) -> np.ndarray:
-    array = np.asarray(matrix, dtype=np.uint8) % 2
+    array = np.asarray(matrix)
     if array.ndim != 2:
         raise ValueError(f"{name} must be two-dimensional")
-    return array
+    if np.any((array != 0) & (array != 1)):
+        raise ValueError(f"{name} must contain only binary values")
+    return np.asarray(array, dtype=np.uint8)
 
 
 def _as_binary_vector(vector: np.ndarray, name: str) -> np.ndarray:
-    array = np.asarray(vector, dtype=np.uint8) % 2
+    array = np.asarray(vector)
     if array.ndim != 1:
         raise ValueError(f"{name} must be one-dimensional")
-    return array
+    if np.any((array != 0) & (array != 1)):
+        raise ValueError(f"{name} must contain only binary values")
+    return np.asarray(array, dtype=np.uint8)
 
 
 def _exact_solver_config(solver: Optional[str], options: dict[str, Any]) -> SolverConfig:

--- a/src/ilpqec/distance_ilp.py
+++ b/src/ilpqec/distance_ilp.py
@@ -1,0 +1,246 @@
+"""Exact ILP helpers for CSS distance calculations."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Optional
+
+import numpy as np
+
+from ilpqec.solver import SolverConfig, get_default_solver
+
+
+@dataclass(frozen=True)
+class MinWeightResult:
+    """Minimum-weight binary vector returned by an exact ILP."""
+
+    vector: np.ndarray
+    weight: int
+    objective: float
+    status: str
+
+
+def _as_binary_matrix(matrix: np.ndarray, name: str) -> np.ndarray:
+    array = np.asarray(matrix, dtype=np.uint8) % 2
+    if array.ndim != 2:
+        raise ValueError(f"{name} must be two-dimensional")
+    return array
+
+
+def _as_binary_vector(vector: np.ndarray, name: str) -> np.ndarray:
+    array = np.asarray(vector, dtype=np.uint8) % 2
+    if array.ndim != 1:
+        raise ValueError(f"{name} must be one-dimensional")
+    return array
+
+
+def _exact_solver_config(solver: Optional[str], options: dict[str, Any]) -> SolverConfig:
+    solver_name = (solver or get_default_solver()).lower()
+    gap = options.pop("gap", None)
+    if gap not in (None, 0, 0.0):
+        raise ValueError(
+            "CSS distance APIs require exact optimization; positive gap is not allowed"
+        )
+
+    direct = options.pop("direct", None)
+    if direct is None:
+        direct = solver_name == "highs"
+    if solver_name != "highs" or not direct:
+        raise ValueError("CSS distance ILP currently supports the direct HiGHS backend")
+
+    return SolverConfig(
+        name=solver_name,
+        time_limit=options.pop("time_limit", None),
+        gap=0.0,
+        threads=options.pop("threads", None),
+        verbose=options.pop("verbose", False),
+        direct=True,
+        options=options,
+    )
+
+
+def minimize_weight_with_fixed_syndrome(
+    parity_check_matrix: np.ndarray,
+    syndrome: np.ndarray,
+    *,
+    solver: str = None,
+    **solver_options,
+) -> MinWeightResult:
+    """Minimize Hamming weight subject to Mx = syndrome over GF(2)."""
+    matrix = _as_binary_matrix(parity_check_matrix, "parity_check_matrix")
+    rhs = _as_binary_vector(syndrome, "syndrome")
+    if matrix.shape[0] != rhs.shape[0]:
+        raise ValueError("Syndrome length must match the number of parity-check rows")
+
+    config = _exact_solver_config(solver, dict(solver_options))
+    return _solve_direct_highs(matrix, rhs, selector_matrix=None, config=config)
+
+
+def minimize_nonzero_logical_operator(
+    check_matrix: np.ndarray,
+    dual_logicals: np.ndarray,
+    *,
+    solver: str = None,
+    **solver_options,
+) -> MinWeightResult:
+    """Minimize Hamming weight with zero syndrome and nonzero dual-logical pairing."""
+    checks = _as_binary_matrix(check_matrix, "check_matrix")
+    duals = _as_binary_matrix(dual_logicals, "dual_logicals")
+    if checks.shape[1] != duals.shape[1]:
+        raise ValueError("check_matrix and dual_logicals must have the same number of columns")
+    if duals.shape[0] == 0:
+        raise ValueError("At least one dual logical is required")
+
+    rhs = np.zeros(checks.shape[0], dtype=np.uint8)
+    config = _exact_solver_config(solver, dict(solver_options))
+    return _solve_direct_highs(checks, rhs, selector_matrix=duals, config=config)
+
+
+def _solve_direct_highs(
+    fixed_matrix: np.ndarray,
+    fixed_rhs: np.ndarray,
+    *,
+    selector_matrix: Optional[np.ndarray],
+    config: SolverConfig,
+) -> MinWeightResult:
+    try:
+        from highspy import (
+            Highs,
+            HighsLp,
+            HighsModelStatus,
+            HighsSparseMatrix,
+            HighsStatus,
+            HighsVarType,
+            MatrixFormat,
+        )
+    except Exception as exc:
+        raise ImportError(
+            "Direct HiGHS backend requires highspy. Install with: pip install highspy"
+        ) from exc
+
+    fixed_matrix = np.asarray(fixed_matrix, dtype=np.uint8)
+    fixed_rhs = np.asarray(fixed_rhs, dtype=np.uint8)
+    selector_matrix = (
+        None if selector_matrix is None else np.asarray(selector_matrix, dtype=np.uint8)
+    )
+
+    n = fixed_matrix.shape[1]
+    num_fixed = fixed_matrix.shape[0]
+    num_selectors = 0 if selector_matrix is None else selector_matrix.shape[0]
+    num_aux = num_fixed + num_selectors
+    num_cols = n + num_aux + num_selectors
+    sum_selector_row = 1 if num_selectors else 0
+    num_rows = num_fixed + num_selectors + sum_selector_row
+
+    highs = Highs()
+    _set_highs_option(highs, HighsStatus, "output_flag", bool(config.verbose))
+    if config.time_limit is not None:
+        _set_highs_option(highs, HighsStatus, "time_limit", float(config.time_limit))
+    if config.threads is not None:
+        _set_highs_option(highs, HighsStatus, "threads", int(config.threads))
+    _set_highs_option(highs, HighsStatus, "mip_rel_gap", 0.0)
+    for key, value in config.options.items():
+        _set_highs_option(highs, HighsStatus, key, value)
+
+    col_cost = [0.0] * num_cols
+    col_lower = [0.0] * num_cols
+    col_upper = [0.0] * num_cols
+    integrality = [HighsVarType.kInteger] * num_cols
+
+    for col in range(n):
+        col_cost[col] = 1.0
+        col_upper[col] = 1.0
+
+    for row in range(num_aux):
+        col_upper[n + row] = float(n)
+
+    selector_offset = n + num_aux
+    for row in range(num_selectors):
+        col_upper[selector_offset + row] = 1.0
+
+    row_lower = [0.0] * num_rows
+    row_upper = [0.0] * num_rows
+
+    for row in range(num_fixed):
+        rhs = float(fixed_rhs[row])
+        row_lower[row] = rhs
+        row_upper[row] = rhs
+
+    for row in range(num_selectors):
+        idx = num_fixed + row
+        row_lower[idx] = 0.0
+        row_upper[idx] = 0.0
+
+    if num_selectors:
+        row_lower[-1] = 1.0
+        row_upper[-1] = float(num_selectors)
+
+    entries = [[] for _ in range(num_cols)]
+    for row in range(num_fixed):
+        for col in np.flatnonzero(fixed_matrix[row]):
+            entries[int(col)].append((row, 1.0))
+        entries[n + row].append((row, -2.0))
+
+    for row in range(num_selectors):
+        constraint_row = num_fixed + row
+        for col in np.flatnonzero(selector_matrix[row]):
+            entries[int(col)].append((constraint_row, 1.0))
+        entries[n + num_fixed + row].append((constraint_row, -2.0))
+        entries[selector_offset + row].append((constraint_row, -1.0))
+        entries[selector_offset + row].append((num_rows - 1, 1.0))
+
+    starts = [0]
+    indices = []
+    values = []
+    for col_entries in entries:
+        for row, value in col_entries:
+            indices.append(int(row))
+            values.append(float(value))
+        starts.append(len(indices))
+
+    matrix = HighsSparseMatrix()
+    matrix.num_row_ = num_rows
+    matrix.num_col_ = num_cols
+    matrix.start_ = starts
+    matrix.index_ = indices
+    matrix.value_ = values
+    matrix.format_ = MatrixFormat.kColwise
+
+    lp = HighsLp()
+    lp.num_col_ = num_cols
+    lp.num_row_ = num_rows
+    lp.col_cost_ = col_cost
+    lp.col_lower_ = col_lower
+    lp.col_upper_ = col_upper
+    lp.row_lower_ = row_lower
+    lp.row_upper_ = row_upper
+    lp.integrality_ = integrality
+    lp.a_matrix_ = matrix
+
+    status = highs.passModel(lp)
+    if status != HighsStatus.kOk:
+        raise RuntimeError("Failed to initialize HiGHS model")
+
+    status = highs.run()
+    if status != HighsStatus.kOk:
+        raise RuntimeError("HiGHS failed to solve CSS distance model")
+
+    model_status = highs.getModelStatus()
+    if model_status != HighsModelStatus.kOptimal:
+        raise RuntimeError(f"HiGHS did not prove optimality: {model_status}")
+
+    solution = highs.getSolution()
+    vector = (np.asarray(solution.col_value[:n], dtype=float) > 0.5).astype(np.uint8)
+    objective = float(highs.getObjectiveValue())
+    return MinWeightResult(
+        vector=vector,
+        weight=int(vector.sum()),
+        objective=objective,
+        status=str(model_status),
+    )
+
+
+def _set_highs_option(highs, highs_status, key: str, value: Any) -> None:
+    status = highs.setOptionValue(key, value)
+    if status != highs_status.kOk:
+        raise ValueError(f"HiGHS rejected option '{key}'")

--- a/src/ilpqec/gf2.py
+++ b/src/ilpqec/gf2.py
@@ -146,7 +146,12 @@ def extend_independent_rows(
 
 
 def quotient_basis(super_space: np.ndarray, sub_space: np.ndarray, dimension: int) -> np.ndarray:
-    """Return representatives for super_space / sub_space."""
+    """Return independent representatives for super_space / sub_space.
+
+    Rows of ``super_space`` are treated as candidate representatives. For CSS
+    logical-basis use, ``sub_space`` is assumed to lie within that rowspace, and
+    ``dimension`` independent rows are selected modulo ``sub_space``.
+    """
     return extend_independent_rows(sub_space, super_space, dimension)
 
 
@@ -156,6 +161,8 @@ def css_logical_basis(hx: np.ndarray, hz: np.ndarray) -> CSSLogicalBasisData:
     hz = _as_gf2_matrix(hz)
     if hx.shape[1] != hz.shape[1]:
         raise ValueError("Hx and Hz must have the same number of columns")
+    if np.any((hx @ hz.T) % 2):
+        raise ValueError("CSS check matrices must commute")
 
     n = hx.shape[1]
     k = n - rank(hx) - rank(hz)

--- a/src/ilpqec/gf2.py
+++ b/src/ilpqec/gf2.py
@@ -1,0 +1,126 @@
+"""Small GF(2) linear algebra helpers used by CSS code analysis."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable
+
+import numpy as np
+
+
+@dataclass(frozen=True)
+class RowReduction:
+    """Reduced row-echelon form data over GF(2)."""
+
+    matrix: np.ndarray
+    pivot_columns: tuple[int, ...]
+    rank: int
+
+
+def _as_gf2_matrix(matrix: np.ndarray) -> np.ndarray:
+    array = np.asarray(matrix, dtype=np.uint8) % 2
+    if array.ndim != 2:
+        raise ValueError("GF(2) matrix must be two-dimensional")
+    return array.copy()
+
+
+def row_reduce(matrix: np.ndarray) -> RowReduction:
+    """Return the reduced row-echelon form of a binary matrix over GF(2)."""
+    reduced = _as_gf2_matrix(matrix)
+    rows, cols = reduced.shape
+    pivot_columns = []
+    pivot_row = 0
+
+    for col in range(cols):
+        candidates = np.flatnonzero(reduced[pivot_row:, col])
+        if candidates.size == 0:
+            continue
+
+        source_row = pivot_row + int(candidates[0])
+        if source_row != pivot_row:
+            reduced[[pivot_row, source_row]] = reduced[[source_row, pivot_row]]
+
+        for row in range(rows):
+            if row != pivot_row and reduced[row, col]:
+                reduced[row] ^= reduced[pivot_row]
+
+        pivot_columns.append(col)
+        pivot_row += 1
+        if pivot_row == rows:
+            break
+
+    return RowReduction(
+        matrix=reduced,
+        pivot_columns=tuple(pivot_columns),
+        rank=len(pivot_columns),
+    )
+
+
+def rank(matrix: np.ndarray) -> int:
+    """Return the GF(2) rank of a binary matrix."""
+    return row_reduce(matrix).rank
+
+
+def row_basis(matrix: np.ndarray) -> np.ndarray:
+    """Return a reduced independent row basis for the rowspace of a binary matrix."""
+    reduced = row_reduce(matrix)
+    return reduced.matrix[: reduced.rank].copy()
+
+
+def nullspace(matrix: np.ndarray) -> np.ndarray:
+    """Return row vectors forming a basis for the right nullspace over GF(2)."""
+    reduced = row_reduce(matrix)
+    rows, cols = reduced.matrix.shape
+    pivots = set(reduced.pivot_columns)
+    free_columns = [col for col in range(cols) if col not in pivots]
+
+    kernel = np.zeros((len(free_columns), cols), dtype=np.uint8)
+    for out_row, free_col in enumerate(free_columns):
+        kernel[out_row, free_col] = 1
+        for pivot_row, pivot_col in enumerate(reduced.pivot_columns):
+            if pivot_row < rows and reduced.matrix[pivot_row, free_col]:
+                kernel[out_row, pivot_col] = 1
+
+    return kernel
+
+
+def binary_inverse(matrix: np.ndarray) -> np.ndarray:
+    """Return the inverse of a full-rank square binary matrix over GF(2)."""
+    matrix = _as_gf2_matrix(matrix)
+    rows, cols = matrix.shape
+    if rows != cols:
+        raise ValueError("Only square binary matrices can be inverted")
+
+    augmented = np.hstack([matrix, np.eye(rows, dtype=np.uint8)])
+    reduced = row_reduce(augmented)
+    left = reduced.matrix[:, :cols]
+    if reduced.rank != rows or not np.array_equal(left, np.eye(rows, dtype=np.uint8)):
+        raise ValueError("Matrix is singular over GF(2)")
+
+    return reduced.matrix[:, cols:].copy()
+
+
+def extend_independent_rows(
+    base: np.ndarray,
+    candidates: Iterable[np.ndarray],
+    count: int,
+) -> np.ndarray:
+    """Select candidate rows that extend the rowspace of base by count dimensions."""
+    current = row_basis(base)
+    selected = []
+    current_rank = rank(current)
+
+    for candidate in candidates:
+        candidate = np.asarray(candidate, dtype=np.uint8).reshape(1, -1) % 2
+        trial = np.vstack([current, candidate])
+        trial_rank = rank(trial)
+        if trial_rank > current_rank:
+            selected.append(candidate.reshape(-1))
+            current = row_basis(trial)
+            current_rank = trial_rank
+            if len(selected) == count:
+                break
+
+    if len(selected) != count:
+        raise ValueError("Could not find enough independent quotient representatives")
+    return np.asarray(selected, dtype=np.uint8)

--- a/src/ilpqec/gf2.py
+++ b/src/ilpqec/gf2.py
@@ -106,6 +106,9 @@ def extend_independent_rows(
     count: int,
 ) -> np.ndarray:
     """Select candidate rows that extend the rowspace of base by count dimensions."""
+    if count < 0:
+        raise ValueError("count must be non-negative")
+
     current = row_basis(base)
     if count == 0:
         return np.zeros((0, current.shape[1]), dtype=np.uint8)
@@ -114,7 +117,12 @@ def extend_independent_rows(
     current_rank = rank(current)
 
     for candidate in candidates:
-        candidate = np.asarray(candidate, dtype=np.uint8).reshape(1, -1) % 2
+        candidate = np.asarray(candidate, dtype=np.int64) % 2
+        if candidate.ndim == 2 and candidate.shape[0] == 1:
+            candidate = candidate[0]
+        if candidate.ndim != 1:
+            raise ValueError("Candidate rows must be one-dimensional")
+        candidate = candidate.astype(np.uint8, copy=False).reshape(1, -1)
         trial = np.vstack([current, candidate])
         trial_rank = rank(trial)
         if trial_rank > current_rank:

--- a/src/ilpqec/gf2.py
+++ b/src/ilpqec/gf2.py
@@ -18,10 +18,10 @@ class RowReduction:
 
 
 def _as_gf2_matrix(matrix: np.ndarray) -> np.ndarray:
-    array = np.asarray(matrix, dtype=np.uint8) % 2
+    array = np.asarray(matrix, dtype=np.int64) % 2
     if array.ndim != 2:
         raise ValueError("GF(2) matrix must be two-dimensional")
-    return array.copy()
+    return array.astype(np.uint8, copy=True)
 
 
 def row_reduce(matrix: np.ndarray) -> RowReduction:
@@ -107,6 +107,9 @@ def extend_independent_rows(
 ) -> np.ndarray:
     """Select candidate rows that extend the rowspace of base by count dimensions."""
     current = row_basis(base)
+    if count == 0:
+        return np.zeros((0, current.shape[1]), dtype=np.uint8)
+
     selected = []
     current_rank = rank(current)
 

--- a/src/ilpqec/gf2.py
+++ b/src/ilpqec/gf2.py
@@ -17,6 +17,14 @@ class RowReduction:
     rank: int
 
 
+@dataclass(frozen=True)
+class CSSLogicalBasisData:
+    """Paired binary CSS logical bases."""
+
+    x: np.ndarray
+    z: np.ndarray
+
+
 def _as_gf2_matrix(matrix: np.ndarray) -> np.ndarray:
     array = np.asarray(matrix, dtype=np.int64) % 2
     if array.ndim != 2:
@@ -135,3 +143,40 @@ def extend_independent_rows(
     if len(selected) != count:
         raise ValueError("Could not find enough independent quotient representatives")
     return np.asarray(selected, dtype=np.uint8)
+
+
+def quotient_basis(super_space: np.ndarray, sub_space: np.ndarray, dimension: int) -> np.ndarray:
+    """Return representatives for super_space / sub_space."""
+    return extend_independent_rows(sub_space, super_space, dimension)
+
+
+def css_logical_basis(hx: np.ndarray, hz: np.ndarray) -> CSSLogicalBasisData:
+    """Compute paired X and Z logical bases for a binary CSS code."""
+    hx = _as_gf2_matrix(hx)
+    hz = _as_gf2_matrix(hz)
+    if hx.shape[1] != hz.shape[1]:
+        raise ValueError("Hx and Hz must have the same number of columns")
+
+    n = hx.shape[1]
+    k = n - rank(hx) - rank(hz)
+    if k < 0:
+        raise ValueError("Computed a negative number of logical qubits")
+    if k == 0:
+        return CSSLogicalBasisData(
+            x=np.zeros((0, n), dtype=np.uint8),
+            z=np.zeros((0, n), dtype=np.uint8),
+        )
+
+    x_candidates = nullspace(hz)
+    z_candidates = nullspace(hx)
+    lx = quotient_basis(x_candidates, row_basis(hx), k)
+    lz = quotient_basis(z_candidates, row_basis(hz), k)
+
+    pairing = (lx @ lz.T) % 2
+    inverse_pairing = binary_inverse(pairing)
+    paired_lz = (inverse_pairing.T @ lz) % 2
+
+    if not np.array_equal((lx @ paired_lz.T) % 2, np.eye(k, dtype=np.uint8)):
+        raise ValueError("Failed to construct paired CSS logical bases")
+
+    return CSSLogicalBasisData(x=lx.astype(np.uint8), z=paired_lz.astype(np.uint8))

--- a/src/ilpqec/solver.py
+++ b/src/ilpqec/solver.py
@@ -16,24 +16,24 @@ Supported Solvers:
 Example:
     # Use default solver (HiGHS)
     decoder = Decoder.from_parity_check_matrix(H)
-    
+
     # Use specific solver
     decoder = Decoder.from_parity_check_matrix(H, solver="highs")
-    
+
     # Change solver
     decoder.set_solver("gurobi", time_limit=60)
 """
 
-from dataclasses import dataclass, field
-from typing import Dict, Any, Optional, List
 import shutil
+from dataclasses import dataclass, field
+from typing import Any, Optional
 
 
 @dataclass
 class SolverConfig:
     """
     Configuration for ILP solver.
-    
+
     Attributes:
         name: Solver name (highs, scip, gurobi, cplex, cbc, glpk)
         time_limit: Maximum solving time in seconds
@@ -49,12 +49,12 @@ class SolverConfig:
     threads: Optional[int] = None
     verbose: bool = False
     direct: bool = False
-    options: Dict[str, Any] = field(default_factory=dict)
-    
-    def to_pyomo_options(self) -> Dict[str, Any]:
+    options: dict[str, Any] = field(default_factory=dict)
+
+    def to_pyomo_options(self) -> dict[str, Any]:
         """Convert to Pyomo solver options."""
-        opts = {}
-        
+        opts: dict[str, Any] = {}
+
         if self.name == "scip":
             if self.time_limit is not None:
                 opts["limits/time"] = self.time_limit
@@ -83,14 +83,17 @@ class SolverConfig:
                 opts["threads"] = self.threads
         elif self.name in ("cbc", "glpk"):
             if self.time_limit is not None:
-                opts["seconds"] = self.time_limit if self.name == "cbc" else None
-                opts["tmlim"] = self.time_limit if self.name == "glpk" else None
+                if self.name == "cbc":
+                    opts["seconds"] = self.time_limit
+                else:
+                    opts["tmlim"] = self.time_limit
             if self.gap is not None:
-                opts["ratioGap"] = self.gap if self.name == "cbc" else None
-        
+                if self.name == "cbc":
+                    opts["ratioGap"] = self.gap
+
         # Add any custom options
         opts.update(self.options)
-        
+
         # Remove None values
         return {k: v for k, v in opts.items() if v is not None}
 
@@ -144,16 +147,16 @@ def require_pyomo() -> None:
         )
 
 
-def get_available_solvers() -> List[str]:
+def get_available_solvers() -> list[str]:
     """
     Get list of available solvers.
-    
+
     Returns:
         List of solver names that are installed and available.
     """
     import logging
     import warnings
-    
+
     available = []
     if _highs_available():
         available.append("highs")
@@ -161,10 +164,10 @@ def get_available_solvers() -> List[str]:
         available.append("gurobi")
     if not is_pyomo_available():
         return list(dict.fromkeys(available))
-    
+
     # Suppress Pyomo warnings during solver detection
     logging.getLogger('pyomo').setLevel(logging.ERROR)
-    
+
     for solver_name, executables in SOLVER_EXECUTABLES.items():
         if solver_name == "highs":
             continue
@@ -189,19 +192,19 @@ def get_available_solvers() -> List[str]:
                             continue
             except Exception:
                 pass
-    
+
     return list(dict.fromkeys(available))
 
 
 def get_default_solver() -> str:
     """
     Get the default solver.
-    
+
     Returns HiGHS if available, otherwise the first available solver.
-    
+
     Returns:
         Name of the default solver.
-        
+
     Raises:
         RuntimeError: If no solver is available.
     """
@@ -213,7 +216,7 @@ def get_default_solver() -> str:
             return solver
     if available:
         return available[0]
-    
+
     raise RuntimeError(
         "No ILP solver available. Please install one of:\n"
         "  - HiGHS: pip install highspy\n"
@@ -225,22 +228,22 @@ def get_default_solver() -> str:
 def get_pyomo_solver_name(solver: str) -> str:
     """
     Get the Pyomo solver name for a given solver.
-    
+
     Args:
         solver: User-facing solver name
-        
+
     Returns:
         Pyomo-compatible solver name
     """
     import logging
     import warnings
-    
+
     # Suppress Pyomo warnings
     logging.getLogger('pyomo').setLevel(logging.ERROR)
-    
+
     # Try executables in order
     executables = SOLVER_EXECUTABLES.get(solver.lower(), [solver])
-    
+
     try:
         from pyomo.environ import SolverFactory
         with warnings.catch_warnings():
@@ -254,6 +257,6 @@ def get_pyomo_solver_name(solver: str) -> str:
                     continue
     except Exception:
         pass
-    
+
     # Return first option as fallback
     return executables[0] if executables else solver

--- a/tests/test_css_analysis_coverage.py
+++ b/tests/test_css_analysis_coverage.py
@@ -1,0 +1,396 @@
+"""Extra coverage tests for CSS analysis helpers and edge cases."""
+
+from __future__ import annotations
+
+import builtins
+import sys
+import types
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+
+import ilpqec.css_code as css_code_module
+import ilpqec.distance_ilp as distance_ilp_module
+from ilpqec import CSSCode
+from ilpqec.distance_ilp import (
+    _exact_solver_config,
+    _set_highs_option,
+    minimize_nonzero_logical_operator,
+    minimize_weight_with_fixed_syndrome,
+)
+from ilpqec.solver import SolverConfig
+
+
+def steane_check_matrix():
+    return np.array(
+        [
+            [1, 0, 1, 0, 1, 0, 1],
+            [0, 1, 1, 0, 0, 1, 1],
+            [0, 0, 0, 1, 1, 1, 1],
+        ],
+        dtype=np.uint8,
+    )
+
+
+def _install_fake_highspy(
+    monkeypatch,
+    *,
+    option_status=0,
+    pass_status=0,
+    run_status=0,
+    model_status=1,
+    objective=2.0,
+    col_value=None,
+):
+    module = types.ModuleType("highspy")
+
+    class FakeHighsStatus:
+        kOk = 0
+        kError = -1
+
+    class FakeHighsModelStatus:
+        kOptimal = 1
+        kTimeLimit = 2
+
+    class FakeHighsVarType:
+        kInteger = 0
+
+    class FakeMatrixFormat:
+        kColwise = 0
+
+    class FakeHighsSparseMatrix:
+        pass
+
+    class FakeHighsLp:
+        pass
+
+    class FakeSolution:
+        def __init__(self, values):
+            self.col_value = values
+
+    class FakeHighs:
+        def __init__(self):
+            self.options = {}
+            self.num_cols = 0
+
+        def setOptionValue(self, key, value):
+            self.options[key] = value
+            return option_status
+
+        def passModel(self, lp):
+            self.num_cols = lp.num_col_
+            return pass_status
+
+        def run(self):
+            return run_status
+
+        def getModelStatus(self):
+            return model_status
+
+        def getSolution(self):
+            if col_value is None:
+                values = [1.0] + [0.0] * max(0, self.num_cols - 1)
+            else:
+                values = list(col_value)
+            return FakeSolution(values)
+
+        def getObjectiveValue(self):
+            return objective
+
+    module.Highs = FakeHighs
+    module.HighsLp = FakeHighsLp
+    module.HighsModelStatus = FakeHighsModelStatus
+    module.HighsSparseMatrix = FakeHighsSparseMatrix
+    module.HighsStatus = FakeHighsStatus
+    module.HighsVarType = FakeHighsVarType
+    module.MatrixFormat = FakeMatrixFormat
+    monkeypatch.setitem(sys.modules, "highspy", module)
+    return FakeHighsStatus, FakeHighsModelStatus
+
+
+def test_to_binary_matrix_rejects_non_two_dimensional_input():
+    with pytest.raises(ValueError, match="two-dimensional"):
+        css_code_module._to_binary_matrix(np.array([1, 0, 1]), "Hx")
+
+
+def test_to_binary_matrix_accepts_scipy_sparse_if_available():
+    scipy = pytest.importorskip("scipy.sparse")
+    matrix = scipy.eye(2, dtype=np.uint8, format="csr")
+
+    out = css_code_module._to_binary_matrix(matrix, "Hx")
+
+    np.testing.assert_array_equal(out, np.eye(2, dtype=np.uint8))
+
+
+def test_to_binary_matrix_requires_scipy_for_sparse_like_objects(monkeypatch):
+    class DummySparse:
+        def toarray(self):
+            return np.eye(2, dtype=np.uint8)
+
+    real_import = builtins.__import__
+
+    def fake_import(name, *args, **kwargs):
+        if name.startswith("scipy"):
+            raise ImportError("no scipy")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+    with pytest.raises(ImportError, match="Sparse CSS parity-check matrices require SciPy"):
+        css_code_module._to_binary_matrix(DummySparse(), "Hx")
+
+
+def test_css_code_init_rejects_negative_logical_qubit_count():
+    hx = np.eye(2, dtype=np.uint8)
+    hz = np.eye(2, dtype=np.uint8)
+
+    with pytest.raises(ValueError, match="negative number of logical qubits"):
+        CSSCode(hx, hz)
+
+
+def test_css_code_init_rejects_shape_mismatch():
+    with pytest.raises(ValueError, match="same number of columns"):
+        CSSCode(np.zeros((1, 3), dtype=np.uint8), np.zeros((1, 4), dtype=np.uint8))
+
+
+def test_canonical_logical_basis_is_cached_once(monkeypatch):
+    calls = []
+
+    def fake_basis(hx, hz):
+        calls.append((hx.copy(), hz.copy()))
+        return SimpleNamespace(
+            x=np.array([[1, 0, 0]], dtype=np.uint8),
+            z=np.array([[0, 1, 0]], dtype=np.uint8),
+        )
+
+    monkeypatch.setattr(css_code_module, "css_logical_basis", fake_basis)
+    code = CSSCode(np.array([[1, 1, 0]], dtype=np.uint8), np.zeros((0, 3), dtype=np.uint8))
+
+    basis1 = code.logical_basis(reduce=False)
+    basis2 = code.logical_basis(reduce=False)
+    basis1.x[0, 0] = 0
+    basis1.z[0, 1] = 0
+
+    assert len(calls) == 1
+    np.testing.assert_array_equal(basis2.x, np.array([[1, 0, 0]], dtype=np.uint8))
+    np.testing.assert_array_equal(basis2.z, np.array([[0, 1, 0]], dtype=np.uint8))
+
+
+def test_distance_forwards_solver_options_and_returns_copies(monkeypatch):
+    h = steane_check_matrix()
+    code = CSSCode.from_parity_check_matrices(h, h)
+    x_vec = np.array([1, 1, 1, 0, 0, 0, 0], dtype=np.uint8)
+    z_vec = np.array([0, 0, 0, 1, 1, 1, 0], dtype=np.uint8)
+    calls = []
+
+    def fake_minimize(check_matrix, dual_logicals, *, solver=None, **solver_options):
+        calls.append((check_matrix.copy(), dual_logicals.copy(), solver, dict(solver_options)))
+        if len(calls) % 2 == 1:
+            return SimpleNamespace(vector=x_vec, weight=3)
+        return SimpleNamespace(vector=z_vec, weight=2)
+
+    monkeypatch.setattr(css_code_module, "minimize_nonzero_logical_operator", fake_minimize)
+
+    result = code.distance(solver="highs", threads=2, verbose=True)
+    result.shortest_x[0] = 0
+    result.shortest_z[3] = 0
+    again = code.distance(solver="highs", threads=2, verbose=True)
+
+    assert result.d == 2
+    assert result.dx == 3
+    assert result.dz == 2
+    assert len(calls) == 4
+    assert all(call[2] == "highs" for call in calls)
+    assert all(call[3] == {"threads": 2, "verbose": True} for call in calls)
+    np.testing.assert_array_equal(again.shortest_x, x_vec)
+    np.testing.assert_array_equal(again.shortest_z, z_vec)
+
+
+def test_logical_basis_reduce_forwards_solver_options(monkeypatch):
+    hx = np.array([[1, 1, 0, 0]], dtype=np.uint8)
+    hz = np.array([[0, 0, 1, 1]], dtype=np.uint8)
+    code = CSSCode.from_parity_check_matrices(hx, hz)
+    calls = []
+    x_outputs = [
+        np.array([1, 0, 1, 0], dtype=np.uint8),
+        np.array([0, 1, 0, 1], dtype=np.uint8),
+    ]
+    z_outputs = [
+        np.array([1, 0, 0, 0], dtype=np.uint8),
+        np.array([0, 0, 1, 0], dtype=np.uint8),
+    ]
+    outputs = [x_outputs[0], z_outputs[0], x_outputs[1], z_outputs[1]]
+
+    def fake_minimize(matrix, syndrome, *, solver=None, **solver_options):
+        calls.append((matrix.copy(), syndrome.copy(), solver, dict(solver_options)))
+        return SimpleNamespace(vector=outputs[len(calls) - 1])
+
+    monkeypatch.setattr(css_code_module, "minimize_weight_with_fixed_syndrome", fake_minimize)
+
+    basis = code.logical_basis(reduce=True, solver="highs", time_limit=5.0)
+
+    assert len(calls) == 4
+    assert all(call[2] == "highs" for call in calls)
+    assert all(call[3] == {"time_limit": 5.0} for call in calls)
+    np.testing.assert_array_equal(basis.x, np.vstack(x_outputs))
+    np.testing.assert_array_equal(basis.z, np.vstack(z_outputs))
+
+
+def test_exact_solver_config_defaults_to_highs_and_preserves_options(monkeypatch):
+    monkeypatch.setattr(distance_ilp_module, "get_default_solver", lambda: "highs")
+
+    config = _exact_solver_config(
+        None,
+        {"time_limit": 1.5, "threads": 4, "verbose": True, "node_limit": 7},
+    )
+
+    assert config == SolverConfig(
+        name="highs",
+        time_limit=1.5,
+        gap=0.0,
+        threads=4,
+        verbose=True,
+        direct=True,
+        options={"node_limit": 7},
+    )
+
+
+def test_exact_solver_config_rejects_non_highs_and_non_direct():
+    with pytest.raises(ValueError, match="direct HiGHS"):
+        _exact_solver_config("cbc", {})
+    with pytest.raises(ValueError, match="direct HiGHS"):
+        _exact_solver_config("highs", {"direct": False})
+
+
+def test_minimize_weight_with_fixed_syndrome_rejects_invalid_shapes():
+    with pytest.raises(ValueError, match="two-dimensional"):
+        minimize_weight_with_fixed_syndrome(
+            np.array([1, 0], dtype=np.uint8),
+            np.zeros(2, dtype=np.uint8),
+            solver="highs",
+        )
+    with pytest.raises(ValueError, match="binary values"):
+        minimize_weight_with_fixed_syndrome(
+            np.eye(2, dtype=np.uint8),
+            np.array([0, 2], dtype=np.int64),
+            solver="highs",
+        )
+    with pytest.raises(ValueError, match="one-dimensional"):
+        minimize_weight_with_fixed_syndrome(
+            np.eye(2, dtype=np.uint8),
+            np.zeros((2, 1), dtype=np.uint8),
+            solver="highs",
+        )
+    with pytest.raises(ValueError, match="Syndrome length must match"):
+        minimize_weight_with_fixed_syndrome(
+            np.eye(2, dtype=np.uint8),
+            np.zeros(1, dtype=np.uint8),
+            solver="highs",
+        )
+
+
+def test_minimize_nonzero_logical_operator_rejects_invalid_duals():
+    with pytest.raises(ValueError, match="binary values"):
+        minimize_nonzero_logical_operator(
+            np.eye(2, dtype=np.uint8),
+            np.array([[0, 2]], dtype=np.int64),
+            solver="highs",
+        )
+    with pytest.raises(ValueError, match="same number of columns"):
+        minimize_nonzero_logical_operator(
+            np.eye(2, dtype=np.uint8),
+            np.ones((1, 3), dtype=np.uint8),
+            solver="highs",
+        )
+    with pytest.raises(ValueError, match="At least one dual logical"):
+        minimize_nonzero_logical_operator(
+            np.eye(2, dtype=np.uint8),
+            np.zeros((0, 2), dtype=np.uint8),
+            solver="highs",
+        )
+
+
+def test_solve_direct_highs_raises_without_highspy(monkeypatch):
+    monkeypatch.delitem(sys.modules, "highspy", raising=False)
+    real_import = builtins.__import__
+
+    def fake_import(name, *args, **kwargs):
+        if name == "highspy":
+            raise ImportError("no highspy")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+    with pytest.raises(ImportError, match="requires highspy"):
+        distance_ilp_module._solve_direct_highs(
+            np.eye(1, dtype=np.uint8),
+            np.zeros(1, dtype=np.uint8),
+            selector_matrix=None,
+            config=SolverConfig(name="highs", direct=True),
+        )
+
+
+def test_set_highs_option_rejects_invalid_option():
+    class FakeStatus:
+        kOk = 0
+
+    class FakeHighs:
+        def setOptionValue(self, key, value):
+            return -1
+
+    with pytest.raises(ValueError, match="rejected option 'bad_option'"):
+        _set_highs_option(FakeHighs(), FakeStatus, "bad_option", 3)
+
+
+def test_solve_direct_highs_rejects_passmodel_failure(monkeypatch):
+    _install_fake_highspy(monkeypatch, pass_status=-1)
+    with pytest.raises(RuntimeError, match="initialize HiGHS model"):
+        distance_ilp_module._solve_direct_highs(
+            np.eye(1, dtype=np.uint8),
+            np.zeros(1, dtype=np.uint8),
+            selector_matrix=None,
+            config=SolverConfig(name="highs", direct=True),
+        )
+
+
+def test_solve_direct_highs_rejects_run_failure(monkeypatch):
+    _install_fake_highspy(monkeypatch, run_status=-1)
+    with pytest.raises(RuntimeError, match="failed to solve CSS distance model"):
+        distance_ilp_module._solve_direct_highs(
+            np.eye(1, dtype=np.uint8),
+            np.zeros(1, dtype=np.uint8),
+            selector_matrix=None,
+            config=SolverConfig(name="highs", direct=True),
+        )
+
+
+def test_solve_direct_highs_requires_optimal_status(monkeypatch):
+    _, model_status = _install_fake_highspy(monkeypatch, model_status=2)
+    with pytest.raises(RuntimeError, match=str(model_status.kTimeLimit)):
+        distance_ilp_module._solve_direct_highs(
+            np.eye(1, dtype=np.uint8),
+            np.zeros(1, dtype=np.uint8),
+            selector_matrix=None,
+            config=SolverConfig(name="highs", direct=True),
+        )
+
+
+def test_solve_direct_highs_passes_solver_configuration(monkeypatch):
+    _install_fake_highspy(monkeypatch, objective=4.0, col_value=[1.0, 0.0, 0.0, 0.0])
+
+    result = distance_ilp_module._solve_direct_highs(
+        np.array([[1, 0]], dtype=np.uint8),
+        np.array([1], dtype=np.uint8),
+        selector_matrix=np.array([[0, 1]], dtype=np.uint8),
+        config=SolverConfig(
+            name="highs",
+            time_limit=3.0,
+            threads=2,
+            verbose=True,
+            direct=True,
+            options={"presolve": "off"},
+        ),
+    )
+
+    np.testing.assert_array_equal(result.vector, np.array([1, 0], dtype=np.uint8))
+    assert result.weight == 1
+    assert result.objective == 4.0

--- a/tests/test_css_code.py
+++ b/tests/test_css_code.py
@@ -43,6 +43,16 @@ def test_css_code_copies_matrices_for_read_only_properties():
     np.testing.assert_array_equal(code.hx, np.array([[1, 1, 0]], dtype=np.uint8))
 
 
+def test_css_code_copies_input_matrices_on_construction():
+    hx = np.array([[1, 1, 0]], dtype=np.uint8)
+    hz = np.zeros((0, 3), dtype=np.uint8)
+
+    code = CSSCode(hx, hz)
+    hx[0, 0] = 0
+
+    np.testing.assert_array_equal(code.hx, np.array([[1, 1, 0]], dtype=np.uint8))
+
+
 def test_css_code_rejects_non_binary_input():
     hx = np.array([[2, 0, 1]], dtype=int)
     hz = np.zeros((0, 3), dtype=np.uint8)
@@ -83,3 +93,11 @@ def test_logical_basis_raises_for_zero_logical_qubits():
 
     with pytest.raises(ValueError, match="no logical qubits"):
         code.logical_basis()
+
+
+def test_logical_basis_rejects_solver_arguments_before_ilp_is_implemented():
+    h = steane_check_matrix()
+    code = CSSCode.from_parity_check_matrices(h, h)
+
+    with pytest.raises(TypeError, match="solver options are not supported"):
+        code.logical_basis(reduce=False, solver="highs")

--- a/tests/test_css_code.py
+++ b/tests/test_css_code.py
@@ -1,0 +1,85 @@
+"""Tests for CSSCode construction and solver-free APIs."""
+
+import numpy as np
+import pytest
+
+from ilpqec import CSSCode
+
+
+def steane_check_matrix():
+    return np.array(
+        [
+            [1, 0, 1, 0, 1, 0, 1],
+            [0, 1, 1, 0, 0, 1, 1],
+            [0, 0, 0, 1, 1, 1, 1],
+        ],
+        dtype=np.uint8,
+    )
+
+
+def test_css_code_properties_and_unreduced_logical_basis():
+    h = steane_check_matrix()
+
+    code = CSSCode.from_parity_check_matrices(h, h)
+    basis = code.logical_basis(reduce=False)
+
+    assert code.n == 7
+    assert code.k == 1
+    assert code.rank_x == 3
+    assert code.rank_z == 3
+    np.testing.assert_array_equal(code.hx, h)
+    np.testing.assert_array_equal(code.hz, h)
+    np.testing.assert_array_equal((basis.x @ basis.z.T) % 2, np.eye(1, dtype=np.uint8))
+
+
+def test_css_code_copies_matrices_for_read_only_properties():
+    hx = np.array([[1, 1, 0]], dtype=np.uint8)
+    hz = np.zeros((0, 3), dtype=np.uint8)
+    code = CSSCode.from_parity_check_matrices(hx, hz)
+
+    hx_copy = code.hx
+    hx_copy[0, 0] = 0
+
+    np.testing.assert_array_equal(code.hx, np.array([[1, 1, 0]], dtype=np.uint8))
+
+
+def test_css_code_rejects_non_binary_input():
+    hx = np.array([[2, 0, 1]], dtype=int)
+    hz = np.zeros((0, 3), dtype=np.uint8)
+
+    with pytest.raises(ValueError, match="binary"):
+        CSSCode.from_parity_check_matrices(hx, hz)
+
+
+def test_css_code_rejects_shape_mismatch():
+    hx = np.zeros((1, 3), dtype=np.uint8)
+    hz = np.zeros((1, 4), dtype=np.uint8)
+
+    with pytest.raises(ValueError, match="same number of columns"):
+        CSSCode.from_parity_check_matrices(hx, hz)
+
+
+def test_css_code_rejects_non_commuting_checks_by_default():
+    hx = np.array([[1, 0]], dtype=np.uint8)
+    hz = np.array([[1, 1]], dtype=np.uint8)
+
+    with pytest.raises(ValueError, match="commute"):
+        CSSCode.from_parity_check_matrices(hx, hz)
+
+
+def test_css_code_can_skip_commutation_validation():
+    hx = np.array([[1, 0]], dtype=np.uint8)
+    hz = np.array([[1, 1]], dtype=np.uint8)
+
+    code = CSSCode.from_parity_check_matrices(hx, hz, validate_commutation=False)
+
+    assert code.n == 2
+
+
+def test_logical_basis_raises_for_zero_logical_qubits():
+    hx = np.eye(2, dtype=np.uint8)
+    hz = np.zeros((0, 2), dtype=np.uint8)
+    code = CSSCode.from_parity_check_matrices(hx, hz)
+
+    with pytest.raises(ValueError, match="no logical qubits"):
+        code.logical_basis()

--- a/tests/test_css_code.py
+++ b/tests/test_css_code.py
@@ -99,5 +99,14 @@ def test_logical_basis_rejects_solver_arguments_before_ilp_is_implemented():
     h = steane_check_matrix()
     code = CSSCode.from_parity_check_matrices(h, h)
 
-    with pytest.raises(TypeError, match="solver options are not supported"):
+    with pytest.raises(TypeError, match="only supported when reduce=True"):
         code.logical_basis(reduce=False, solver="highs")
+
+
+def test_distance_raises_for_zero_logical_qubits():
+    hx = np.eye(2, dtype=np.uint8)
+    hz = np.zeros((0, 2), dtype=np.uint8)
+    code = CSSCode.from_parity_check_matrices(hx, hz)
+
+    with pytest.raises(ValueError, match="no logical qubits"):
+        code.distance()

--- a/tests/test_css_distance.py
+++ b/tests/test_css_distance.py
@@ -78,3 +78,19 @@ def test_exact_ilp_rejects_positive_gap():
 
     with pytest.raises(ValueError, match="exact"):
         minimize_weight_with_fixed_syndrome(matrix, syndrome, solver="highs", gap=0.1)
+
+
+def test_nonzero_logical_operator_rejects_positive_gap():
+    checks = np.array([[1, 1, 0, 0]], dtype=np.uint8)
+    duals = np.array([[0, 0, 1, 0]], dtype=np.uint8)
+
+    with pytest.raises(ValueError, match="exact"):
+        minimize_nonzero_logical_operator(checks, duals, solver="highs", gap=0.1)
+
+
+def test_exact_ilp_rejects_non_binary_matrix_input():
+    matrix = np.array([[1, 2]], dtype=np.int64)
+    syndrome = np.array([0], dtype=np.uint8)
+
+    with pytest.raises(ValueError, match="binary"):
+        minimize_weight_with_fixed_syndrome(matrix, syndrome, solver="highs")

--- a/tests/test_css_distance.py
+++ b/tests/test_css_distance.py
@@ -1,0 +1,80 @@
+"""Tests for exact CSS distance and logical reduction ILPs."""
+
+from itertools import product
+
+import numpy as np
+import pytest
+
+from ilpqec.distance_ilp import (
+    minimize_nonzero_logical_operator,
+    minimize_weight_with_fixed_syndrome,
+)
+from ilpqec.solver import get_available_solvers
+
+
+pytestmark = pytest.mark.skipif(
+    "highs" not in get_available_solvers(),
+    reason="CSS distance ILP tests require the HiGHS backend",
+)
+
+
+def brute_force_fixed(checks, duals, rhs):
+    checks = np.asarray(checks, dtype=np.uint8)
+    duals = np.asarray(duals, dtype=np.uint8)
+    rhs = np.asarray(rhs, dtype=np.uint8)
+    n = checks.shape[1] if checks.size else duals.shape[1]
+    for weight in range(n + 1):
+        for bits in product([0, 1], repeat=n):
+            vector = np.array(bits, dtype=np.uint8)
+            if int(vector.sum()) != weight:
+                continue
+            if checks.size and np.any((checks @ vector) % 2):
+                continue
+            if np.array_equal((duals @ vector) % 2, rhs):
+                return vector
+    raise AssertionError("No feasible vector found")
+
+
+def test_minimize_weight_with_fixed_syndrome_matches_bruteforce():
+    checks = np.array([[1, 1, 0, 0]], dtype=np.uint8)
+    duals = np.array(
+        [
+            [0, 0, 1, 0],
+            [1, 0, 0, 0],
+        ],
+        dtype=np.uint8,
+    )
+    rhs = np.array([1, 0], dtype=np.uint8)
+    matrix = np.vstack([checks, duals])
+    syndrome = np.concatenate([np.zeros(checks.shape[0], dtype=np.uint8), rhs])
+
+    result = minimize_weight_with_fixed_syndrome(matrix, syndrome, solver="highs")
+
+    expected = brute_force_fixed(checks, duals, rhs)
+    np.testing.assert_array_equal((matrix @ result.vector) % 2, syndrome)
+    assert result.weight == int(expected.sum())
+
+
+def test_minimize_nonzero_logical_operator_finds_weight_one_operator():
+    checks = np.array([[1, 1, 0, 0]], dtype=np.uint8)
+    duals = np.array(
+        [
+            [0, 0, 1, 0],
+            [1, 0, 0, 0],
+        ],
+        dtype=np.uint8,
+    )
+
+    result = minimize_nonzero_logical_operator(checks, duals, solver="highs")
+
+    assert result.weight == 1
+    assert not np.any((checks @ result.vector) % 2)
+    assert np.any((duals @ result.vector) % 2)
+
+
+def test_exact_ilp_rejects_positive_gap():
+    matrix = np.array([[1, 1]], dtype=np.uint8)
+    syndrome = np.array([0], dtype=np.uint8)
+
+    with pytest.raises(ValueError, match="exact"):
+        minimize_weight_with_fixed_syndrome(matrix, syndrome, solver="highs", gap=0.1)

--- a/tests/test_css_distance.py
+++ b/tests/test_css_distance.py
@@ -5,6 +5,7 @@ from itertools import product
 import numpy as np
 import pytest
 
+from ilpqec import CSSCode
 from ilpqec.distance_ilp import (
     minimize_nonzero_logical_operator,
     minimize_weight_with_fixed_syndrome,
@@ -94,3 +95,71 @@ def test_exact_ilp_rejects_non_binary_matrix_input():
 
     with pytest.raises(ValueError, match="binary"):
         minimize_weight_with_fixed_syndrome(matrix, syndrome, solver="highs")
+
+
+def steane_check_matrix():
+    return np.array(
+        [
+            [1, 0, 1, 0, 1, 0, 1],
+            [0, 1, 1, 0, 0, 1, 1],
+            [0, 0, 0, 1, 1, 1, 1],
+        ],
+        dtype=np.uint8,
+    )
+
+
+def assert_valid_distance_result(code, result):
+    assert result.d == min(result.dx, result.dz)
+    assert result.dx == int(result.shortest_x.sum())
+    assert result.dz == int(result.shortest_z.sum())
+    assert not np.any((code.hz @ result.shortest_x) % 2)
+    assert not np.any((code.hx @ result.shortest_z) % 2)
+
+
+def test_css_code_distance_for_steane_code():
+    h = steane_check_matrix()
+    code = CSSCode.from_parity_check_matrices(h, h)
+
+    result = code.distance(solver="highs")
+
+    assert result.d == 3
+    assert result.dx == 3
+    assert result.dz == 3
+    assert_valid_distance_result(code, result)
+
+
+def test_css_code_distance_for_two_logical_toy_code():
+    hx = np.array([[1, 1, 0, 0]], dtype=np.uint8)
+    hz = np.array([[0, 0, 1, 1]], dtype=np.uint8)
+    code = CSSCode.from_parity_check_matrices(hx, hz)
+
+    result = code.distance(solver="highs")
+
+    assert result.d == 1
+    assert result.dx == 1
+    assert result.dz == 1
+    assert_valid_distance_result(code, result)
+
+
+def test_reduced_logical_basis_is_paired_and_fixed_coset_minimal():
+    hx = np.array([[1, 1, 0, 0]], dtype=np.uint8)
+    hz = np.array([[0, 0, 1, 1]], dtype=np.uint8)
+    code = CSSCode.from_parity_check_matrices(hx, hz)
+
+    canonical = code.logical_basis(reduce=False)
+    basis = code.logical_basis(reduce=True, solver="highs")
+
+    np.testing.assert_array_equal((basis.x @ basis.z.T) % 2, np.eye(2, dtype=np.uint8))
+    for index in range(code.k):
+        rhs = np.zeros(code.k, dtype=np.uint8)
+        rhs[index] = 1
+
+        assert not np.any((hz @ basis.x[index]) % 2)
+        assert not np.any((hx @ basis.z[index]) % 2)
+        np.testing.assert_array_equal((canonical.z @ basis.x[index]) % 2, rhs)
+        np.testing.assert_array_equal((canonical.x @ basis.z[index]) % 2, rhs)
+
+        expected_x = brute_force_fixed(hz, canonical.z, rhs)
+        expected_z = brute_force_fixed(hx, canonical.x, rhs)
+        assert int(basis.x[index].sum()) == int(expected_x.sum())
+        assert int(basis.z[index].sum()) == int(expected_z.sum())

--- a/tests/test_css_distance.py
+++ b/tests/test_css_distance.py
@@ -163,3 +163,41 @@ def test_reduced_logical_basis_is_paired_and_fixed_coset_minimal():
         expected_z = brute_force_fixed(hx, canonical.x, rhs)
         assert int(basis.x[index].sum()) == int(expected_x.sum())
         assert int(basis.z[index].sum()) == int(expected_z.sum())
+
+
+def test_css_code_distance_for_three_logical_toy_code():
+    hx = np.array([[1, 1, 0, 0, 0]], dtype=np.uint8)
+    hz = np.array([[0, 0, 1, 1, 0]], dtype=np.uint8)
+    code = CSSCode.from_parity_check_matrices(hx, hz)
+
+    result = code.distance(solver="highs")
+
+    assert code.k == 3
+    assert result.d == 1
+    assert result.dx == 1
+    assert result.dz == 1
+    assert_valid_distance_result(code, result)
+
+
+def test_reduced_logical_basis_is_paired_and_fixed_coset_minimal_for_three_logicals():
+    hx = np.array([[1, 1, 0, 0, 0]], dtype=np.uint8)
+    hz = np.array([[0, 0, 1, 1, 0]], dtype=np.uint8)
+    code = CSSCode.from_parity_check_matrices(hx, hz)
+
+    canonical = code.logical_basis(reduce=False)
+    basis = code.logical_basis(reduce=True, solver="highs")
+
+    np.testing.assert_array_equal((basis.x @ basis.z.T) % 2, np.eye(3, dtype=np.uint8))
+    for index in range(code.k):
+        rhs = np.zeros(code.k, dtype=np.uint8)
+        rhs[index] = 1
+
+        assert not np.any((hz @ basis.x[index]) % 2)
+        assert not np.any((hx @ basis.z[index]) % 2)
+        np.testing.assert_array_equal((canonical.z @ basis.x[index]) % 2, rhs)
+        np.testing.assert_array_equal((canonical.x @ basis.z[index]) % 2, rhs)
+
+        expected_x = brute_force_fixed(hz, canonical.z, rhs)
+        expected_z = brute_force_fixed(hx, canonical.x, rhs)
+        assert int(basis.x[index].sum()) == int(expected_x.sum())
+        assert int(basis.z[index].sum()) == int(expected_z.sum())

--- a/tests/test_gf2.py
+++ b/tests/test_gf2.py
@@ -177,6 +177,30 @@ def test_extend_independent_rows_raises_when_not_enough_independent_rows():
         extend_independent_rows(base, candidates, count=1)
 
 
+def test_extend_independent_rows_normalizes_candidate_rows_before_selection():
+    base = np.array(
+        [
+            [1, 0],
+        ],
+        dtype=np.uint8,
+    )
+    candidates = [
+        np.array([2, 3], dtype=object),
+    ]
+
+    selected = extend_independent_rows(base, candidates, count=1)
+
+    expected = np.array([[0, 1]], dtype=np.uint8)
+    np.testing.assert_array_equal(selected, expected)
+
+
+def test_extend_independent_rows_rejects_negative_count():
+    base = np.array([[1, 0]], dtype=np.uint8)
+
+    with pytest.raises(ValueError, match="count"):
+        extend_independent_rows(base, [], count=-1)
+
+
 @pytest.mark.parametrize("candidates", [[np.array([1, 0, 1], dtype=np.uint8)], []])
 def test_extend_independent_rows_zero_count_returns_empty_matrix(candidates):
     base = np.array(

--- a/tests/test_gf2.py
+++ b/tests/test_gf2.py
@@ -1,0 +1,93 @@
+"""Tests for GF(2) linear algebra helpers."""
+
+import numpy as np
+import pytest
+
+from ilpqec.gf2 import binary_inverse, nullspace, rank, row_basis, row_reduce
+
+
+def test_row_reduce_returns_reduced_echelon_form_and_pivots():
+    matrix = np.array(
+        [
+            [1, 1, 0, 1],
+            [1, 0, 1, 1],
+            [0, 1, 1, 0],
+        ],
+        dtype=np.uint8,
+    )
+
+    reduced = row_reduce(matrix)
+
+    expected = np.array(
+        [
+            [1, 0, 1, 1],
+            [0, 1, 1, 0],
+            [0, 0, 0, 0],
+        ],
+        dtype=np.uint8,
+    )
+    np.testing.assert_array_equal(reduced.matrix, expected)
+    assert reduced.pivot_columns == (0, 1)
+    assert reduced.rank == 2
+
+
+def test_rank_and_row_basis_ignore_dependent_rows():
+    matrix = np.array(
+        [
+            [1, 1, 0],
+            [0, 1, 1],
+            [1, 0, 1],
+        ],
+        dtype=np.uint8,
+    )
+
+    assert rank(matrix) == 2
+    basis = row_basis(matrix)
+    assert basis.shape == (2, 3)
+    assert rank(basis) == 2
+    assert rank(np.vstack([basis, matrix])) == 2
+
+
+def test_nullspace_vectors_are_a_basis():
+    matrix = np.array(
+        [
+            [1, 1, 0, 0],
+            [0, 1, 1, 0],
+        ],
+        dtype=np.uint8,
+    )
+
+    kernel = nullspace(matrix)
+
+    assert kernel.shape == (2, 4)
+    np.testing.assert_array_equal((matrix @ kernel.T) % 2, np.zeros((2, 2), dtype=np.uint8))
+    assert rank(kernel) == 2
+
+
+def test_binary_inverse_inverts_full_rank_matrix():
+    matrix = np.array(
+        [
+            [1, 1, 0],
+            [0, 1, 1],
+            [1, 0, 0],
+        ],
+        dtype=np.uint8,
+    )
+
+    inverse = binary_inverse(matrix)
+
+    np.testing.assert_array_equal((matrix @ inverse) % 2, np.eye(3, dtype=np.uint8))
+    np.testing.assert_array_equal((inverse @ matrix) % 2, np.eye(3, dtype=np.uint8))
+
+
+def test_binary_inverse_rejects_singular_matrix():
+    matrix = np.array(
+        [
+            [1, 0],
+            [1, 0],
+        ],
+        dtype=np.uint8,
+    )
+
+    with pytest.raises(ValueError, match="singular"):
+        binary_inverse(matrix)

--- a/tests/test_gf2.py
+++ b/tests/test_gf2.py
@@ -8,6 +8,7 @@ from ilpqec.gf2 import (
     css_logical_basis,
     extend_independent_rows,
     nullspace,
+    quotient_basis,
     rank,
     row_basis,
     row_reduce,
@@ -252,3 +253,40 @@ def test_css_logical_basis_for_two_logical_code_is_paired():
     np.testing.assert_array_equal((hz @ basis.x.T) % 2, np.zeros((1, 2), dtype=np.uint8))
     np.testing.assert_array_equal((hx @ basis.z.T) % 2, np.zeros((1, 2), dtype=np.uint8))
     np.testing.assert_array_equal((basis.x @ basis.z.T) % 2, np.eye(2, dtype=np.uint8))
+
+
+def test_css_logical_basis_rejects_non_commuting_checks():
+    hx = np.array([[1, 0, 0]], dtype=np.uint8)
+    hz = np.array([[1, 0, 0]], dtype=np.uint8)
+
+    with pytest.raises(ValueError, match="commute"):
+        css_logical_basis(hx, hz)
+
+
+def test_css_logical_basis_repairs_non_identity_initial_pairing():
+    hx = np.array([[1, 1, 1]], dtype=np.uint8)
+    hz = np.zeros((0, 3), dtype=np.uint8)
+
+    basis = css_logical_basis(hx, hz)
+
+    assert basis.x.shape == (2, 3)
+    assert basis.z.shape == (2, 3)
+    np.testing.assert_array_equal((hx @ basis.z.T) % 2, np.zeros((1, 2), dtype=np.uint8))
+    np.testing.assert_array_equal((basis.x @ basis.z.T) % 2, np.eye(2, dtype=np.uint8))
+
+    raw_z = quotient_basis(nullspace(hx), row_basis(hz), dimension=2)
+    np.testing.assert_array_equal(
+        (basis.x @ raw_z.T) % 2,
+        np.array([[1, 1], [1, 0]], dtype=np.uint8),
+    )
+    assert not np.array_equal(basis.z, raw_z)
+
+
+def test_css_logical_basis_returns_empty_bases_for_zero_logical_qubits():
+    hx = np.eye(2, dtype=np.uint8)
+    hz = np.zeros((0, 2), dtype=np.uint8)
+
+    basis = css_logical_basis(hx, hz)
+
+    assert basis.x.shape == (0, 2)
+    assert basis.z.shape == (0, 2)

--- a/tests/test_gf2.py
+++ b/tests/test_gf2.py
@@ -3,7 +3,14 @@
 import numpy as np
 import pytest
 
-from ilpqec.gf2 import binary_inverse, nullspace, rank, row_basis, row_reduce
+from ilpqec.gf2 import (
+    binary_inverse,
+    extend_independent_rows,
+    nullspace,
+    rank,
+    row_basis,
+    row_reduce,
+)
 
 
 def test_row_reduce_returns_reduced_echelon_form_and_pivots():
@@ -28,6 +35,28 @@ def test_row_reduce_returns_reduced_echelon_form_and_pivots():
     )
     np.testing.assert_array_equal(reduced.matrix, expected)
     assert reduced.pivot_columns == (0, 1)
+    assert reduced.rank == 2
+
+
+def test_row_reduce_normalizes_python_ints_before_reducing():
+    matrix = np.array(
+        [
+            [-1, 256],
+            [2, 3],
+        ],
+        dtype=object,
+    )
+
+    reduced = row_reduce(matrix)
+
+    expected = np.array(
+        [
+            [1, 0],
+            [0, 1],
+        ],
+        dtype=np.uint8,
+    )
+    np.testing.assert_array_equal(reduced.matrix, expected)
     assert reduced.rank == 2
 
 
@@ -91,3 +120,74 @@ def test_binary_inverse_rejects_singular_matrix():
 
     with pytest.raises(ValueError, match="singular"):
         binary_inverse(matrix)
+
+
+def test_binary_inverse_rejects_non_square_matrix():
+    matrix = np.array(
+        [
+            [1, 0, 1],
+            [0, 1, 1],
+        ],
+        dtype=np.uint8,
+    )
+
+    with pytest.raises(ValueError, match="square"):
+        binary_inverse(matrix)
+
+
+def test_extend_independent_rows_selects_independent_candidates():
+    base = np.array(
+        [
+            [1, 0, 0],
+        ],
+        dtype=np.uint8,
+    )
+    candidates = [
+        np.array([1, 0, 0], dtype=np.uint8),
+        np.array([0, 1, 0], dtype=np.uint8),
+        np.array([0, 0, 1], dtype=np.uint8),
+    ]
+
+    selected = extend_independent_rows(base, candidates, count=2)
+
+    expected = np.array(
+        [
+            [0, 1, 0],
+            [0, 0, 1],
+        ],
+        dtype=np.uint8,
+    )
+    np.testing.assert_array_equal(selected, expected)
+    assert rank(np.vstack([base, selected])) == 3
+
+
+def test_extend_independent_rows_raises_when_not_enough_independent_rows():
+    base = np.array(
+        [
+            [1, 0, 0],
+        ],
+        dtype=np.uint8,
+    )
+    candidates = [
+        np.array([1, 0, 0], dtype=np.uint8),
+        np.array([0, 0, 0], dtype=np.uint8),
+    ]
+
+    with pytest.raises(ValueError, match="independent quotient representatives"):
+        extend_independent_rows(base, candidates, count=1)
+
+
+@pytest.mark.parametrize("candidates", [[np.array([1, 0, 1], dtype=np.uint8)], []])
+def test_extend_independent_rows_zero_count_returns_empty_matrix(candidates):
+    base = np.array(
+        [
+            [1, 0, 0],
+            [0, 1, 0],
+        ],
+        dtype=np.uint8,
+    )
+
+    selected = extend_independent_rows(base, candidates, count=0)
+
+    assert selected.shape == (0, 3)
+    assert selected.dtype == np.uint8

--- a/tests/test_gf2.py
+++ b/tests/test_gf2.py
@@ -5,6 +5,7 @@ import pytest
 
 from ilpqec.gf2 import (
     binary_inverse,
+    css_logical_basis,
     extend_independent_rows,
     nullspace,
     rank,
@@ -215,3 +216,39 @@ def test_extend_independent_rows_zero_count_returns_empty_matrix(candidates):
 
     assert selected.shape == (0, 3)
     assert selected.dtype == np.uint8
+
+
+def steane_check_matrix():
+    return np.array(
+        [
+            [1, 0, 1, 0, 1, 0, 1],
+            [0, 1, 1, 0, 0, 1, 1],
+            [0, 0, 0, 1, 1, 1, 1],
+        ],
+        dtype=np.uint8,
+    )
+
+
+def test_css_logical_basis_for_steane_code_is_paired():
+    h = steane_check_matrix()
+
+    basis = css_logical_basis(h, h)
+
+    assert basis.x.shape == (1, 7)
+    assert basis.z.shape == (1, 7)
+    np.testing.assert_array_equal((h @ basis.x.T) % 2, np.zeros((3, 1), dtype=np.uint8))
+    np.testing.assert_array_equal((h @ basis.z.T) % 2, np.zeros((3, 1), dtype=np.uint8))
+    np.testing.assert_array_equal((basis.x @ basis.z.T) % 2, np.eye(1, dtype=np.uint8))
+
+
+def test_css_logical_basis_for_two_logical_code_is_paired():
+    hx = np.array([[1, 1, 0, 0]], dtype=np.uint8)
+    hz = np.array([[0, 0, 1, 1]], dtype=np.uint8)
+
+    basis = css_logical_basis(hx, hz)
+
+    assert basis.x.shape == (2, 4)
+    assert basis.z.shape == (2, 4)
+    np.testing.assert_array_equal((hz @ basis.x.T) % 2, np.zeros((1, 2), dtype=np.uint8))
+    np.testing.assert_array_equal((hx @ basis.z.T) % 2, np.zeros((1, 2), dtype=np.uint8))
+    np.testing.assert_array_equal((basis.x @ basis.z.T) % 2, np.eye(2, dtype=np.uint8))


### PR DESCRIPTION
## Summary
- add `CSSCode` APIs for binary CSS parity-check analysis, including exact `distance()` results and paired `logical_basis()` with optional strict per-coset ILP reduction
- add GF(2) and exact HiGHS ILP support for shortest logical operators and minimum-weight fixed-coset representatives, plus expanded CSS-specific tests that drive `css_code.py` and `distance_ilp.py` to 100% coverage
- expand the CSS analysis docs and README with dependency requirements, API selection guidance, exactness limits, and common error cases
- clean up repo-wide lint/type checking so `ruff` and `mypy` pass on `src/ilpqec`

## Test Plan
- [x] `uv run pytest tests/test_css_analysis_coverage.py tests/test_css_code.py tests/test_css_distance.py tests/test_gf2.py -v`
- [x] `uv run pytest tests/ -v`
- [x] `uv run pytest tests/test_css_analysis_coverage.py tests/test_css_code.py tests/test_css_distance.py tests/test_gf2.py --cov=ilpqec.css_code --cov=ilpqec.distance_ilp --cov-report=term-missing`
- [x] `.venv/bin/ruff check src/ilpqec`
- [x] `.venv/bin/mypy src/ilpqec`